### PR TITLE
chore: release 4.1.0

### DIFF
--- a/custom_components/scribe/manifest.json
+++ b/custom_components/scribe/manifest.json
@@ -14,5 +14,5 @@
         "asyncpg>=0.28.0"
     ],
     "single_config_entry": true,
-    "version": "4.1.0rc2"
+    "version": "4.1.0"
 }


### PR DESCRIPTION
Stable release **4.1.0**. The `custom_components/scribe/` content is identical to **4.1.0rc2**; only the version in `manifest.json` changes (`git diff v4.1.0rc2 -- custom_components/` is empty apart from that line). The `[4.1.0]` entry in the CHANGELOG is already dated 2026-09-11.

## Checked on the maintainer's instance (Home Assistant 2026.9.1, Scribe 4.1.0rc2)

- Clean startup: the database initialises, the writer starts, and Scribe logs no error or warning.
- The #56 deprecation was logged at startup on 09-07 with the previous version. It no longer appears.
- States are written live, with a lag of 1.4 s. Events are recorded as well.
- All 103 devices in the registry are present in `devices`, with the same data. There are no child devices on this instance.
- No active Scribe issue in Repairs.
- TimescaleDB: `states_raw` and `events` are hypertables with 7-day chunks, as configured. Their compression policies ran successfully this morning, with 0 failures.
- A database restart during the night (01:07) was recovered in 5 s without loss: the batch was put back in the queue and written.