### PR TITLE
fix(writer): turning TLS off left the degraded-TLS repair up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **Turning TLS off left the "TLS is not fully in force" repair up**: the issue describes a certificate that could not be loaded, and disabling TLS in the options makes it moot — but the entry reloads without restarting Home Assistant, and nothing retired the issue until the next restart. It now clears as soon as Scribe starts without TLS.
+
 ## [4.1.0] - 2026-09-11
 
 ### Fixed

--- a/custom_components/scribe/writer.py
+++ b/custom_components/scribe/writer.py
@@ -683,6 +683,10 @@ class ScribeWriter:
         in an executor rather than on the event loop.
         """
         if not self.use_ssl:
+            # Turning TLS off reloads the entry without restarting Home
+            # Assistant: an issue about certificates no longer in use would
+            # otherwise stay up until the next restart.
+            self._clear_issue(ISSUE_SSL_DEGRADED)
             return False
 
         def resolve_path(path_str):

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -443,7 +443,7 @@ Scribe reports conditions it cannot fix itself in Settings → System → Repair
 | `legacy_schema` | `legacy_schema` | error | a pre-3.0 database is detected | the next successful `init_db` |
 | `view_failed` | `view_failed` | error | the `states` view cannot be created | the view is created |
 | `no_timescaledb` | `no_timescaledb` | warning | the extension is missing and cannot be enabled | the extension is found |
-| `ssl_degraded` | `ssl_degraded` | warning | a configured certificate could not be loaded | the TLS context builds without problems |
+| `ssl_degraded` | `ssl_degraded` | warning | a configured certificate could not be loaded | the TLS context builds without problems, or TLS is turned off |
 | `no_hypertable_<table>` | `no_hypertable` | warning | TimescaleDB is installed but the table is not a hypertable | the table is a hypertable, or TimescaleDB is absent |
 | `no_compression_<table>` | `no_compression` | warning | the hypertable has no compression policy | a compression policy exists |
 | `retention_failed_<table>` | `retention_failed` | error | the retention interval is invalid, or the policy could not be applied | the policy is applied, or retention is emptied |

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -189,3 +189,21 @@ async def test_a_healthy_tls_setup_retires_the_issue(hass, certs):
         await writer._build_ssl_context()
 
     clear.assert_called_once_with(ISSUE_SSL_DEGRADED)
+
+
+@pytest.mark.asyncio
+async def test_turning_tls_off_retires_the_issue(hass):
+    """Turning TLS off in the options reloads the entry without restarting.
+
+    A degraded-TLS issue raised by the previous configuration describes a
+    certificate that is no longer in use, and it stayed up until the next
+    Home Assistant restart.
+    """
+    from unittest.mock import patch
+
+    writer = _writer(hass, use_ssl=False)
+
+    with patch.object(writer, "_clear_issue") as clear:
+        assert await writer._build_ssl_context() is False
+
+    clear.assert_called_once_with(ISSUE_SSL_DEGRADED)


### PR DESCRIPTION
## The problem

The "TLS is not fully in force" notification (`ssl_degraded`) is raised when a configured certificate cannot be loaded. It was cleared only when the TLS context built without problems.

With TLS turned off, that context is never built: `_build_ssl_context` returned before reaching the clearing. Turning TLS off in the options reloads the entry without restarting Home Assistant, so the notification stayed up until the next restart. It described a certificate that was no longer in use.

## The fix

When TLS is off, `_build_ssl_context` clears the issue before returning.

## Verification

- A new test, `test_turning_tls_off_retires_the_issue`, failed on the old code and passes with the fix.
- Unit tests and `tests/integration/test_repairs.py` pass.
- The CHANGELOG gets an entry under `[Unreleased]`, and the Repairs table in `docs/DEVELOPMENT.md` §10 is updated.

This is a user-visible fix, so it will ship with the next release (4.1.1 or 4.2.0). No release on its own.