### PR TITLE
test: upgrade tests from every older release, and a stable CI database

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,9 +13,9 @@ jobs:
     name: Run Unit Tests
     runs-on: ubuntu-latest
 
-    # Real TimescaleDB for tests/test_rename_integration.py. Without it those
-    # tests skip themselves, and the rename paths are only covered by mocks —
-    # which is how a primary-key violation in the history merge reached a beta.
+    # Real TimescaleDB for tests/integration/. Without it those tests skip
+    # themselves, and the database paths are only covered by mocks — which is
+    # how a primary-key violation in the history merge reached a beta.
     services:
       timescaledb:
         image: timescale/timescaledb:latest-pg17
@@ -61,7 +61,8 @@ jobs:
         env:
           SCRIBE_TEST_DSN: postgresql://postgres:scribe@127.0.0.1:55432/scribe
         run: |
-          pytest tests \
+          # tests/upgrade has its own job below: it needs the release tags.
+          pytest tests --ignore=tests/upgrade \
             --cov=custom_components/scribe \
             --cov-report=term-missing \
             --cov-fail-under=83
@@ -85,5 +86,58 @@ jobs:
             | tee /tmp/integration.txt
           if grep -q "skipped" /tmp/integration.txt; then
             echo "::error::Integration tests skipped — the TimescaleDB service is unreachable."
+            exit 1
+          fi
+
+  upgrade:
+    name: Upgrade from older releases
+    runs-on: ubuntu-latest
+
+    # Every other test starts from an empty database. This one has each older
+    # release fill a database with its own code, then opens it with this
+    # checkout — the path every existing user takes on an update.
+    services:
+      timescaledb:
+        image: timescale/timescaledb:latest-pg17
+        env:
+          POSTGRES_PASSWORD: scribe
+          POSTGRES_DB: scribe
+        ports:
+          - 55432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # The older releases are checked out from their tags.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+          allow-prereleases: true
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install homeassistant
+          pip install -r requirements_test.txt
+
+      - name: Upgrade from each older release
+        # Skipped means no database or no tags reached the tests, which must
+        # not pass as green.
+        env:
+          SCRIBE_TEST_DSN: postgresql://postgres:scribe@127.0.0.1:55432/scribe
+        run: |
+          set -o pipefail  # a failing test must fail the step, not tee
+          pytest tests/upgrade -v -p no:cacheprovider | tee /tmp/upgrade.txt
+          if grep -q "skipped" /tmp/upgrade.txt; then
+            echo "::error::Upgrade tests skipped — no TimescaleDB or no release tags."
             exit 1
           fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,6 +34,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         
+      - name: Keep TimescaleDB's background jobs out of the tests
+        # The scheduler runs retention and compression jobs on the tables the
+        # tests create, and cancelling one because a test dropped its table
+        # has crashed the whole server (a segfault in policy_retention on
+        # timescaledb:latest-pg17). Tests that need a job run it themselves.
+        run: |
+          docker exec ${{ job.services.timescaledb.id }} \
+            psql -U postgres -c "ALTER SYSTEM SET timescaledb.max_background_workers = 0"
+          docker restart ${{ job.services.timescaledb.id }}
+          until docker exec ${{ job.services.timescaledb.id }} pg_isready -U postgres -q; do sleep 1; done
+
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
@@ -116,6 +127,17 @@ jobs:
         with:
           # The older releases are checked out from their tags.
           fetch-depth: 0
+
+      - name: Keep TimescaleDB's background jobs out of the tests
+        # The scheduler runs retention and compression jobs on the tables the
+        # tests create, and cancelling one because a test dropped its table
+        # has crashed the whole server (a segfault in policy_retention on
+        # timescaledb:latest-pg17). Tests that need a job run it themselves.
+        run: |
+          docker exec ${{ job.services.timescaledb.id }} \
+            psql -U postgres -c "ALTER SYSTEM SET timescaledb.max_background_workers = 0"
+          docker restart ${{ job.services.timescaledb.id }}
+          until docker exec ${{ job.services.timescaledb.id }} pg_isready -U postgres -q; do sleep 1; done
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.github/workflows/upstream-watch.yaml
+++ b/.github/workflows/upstream-watch.yaml
@@ -40,6 +40,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Keep TimescaleDB's background jobs out of the tests
+        # The scheduler runs retention and compression jobs on the tables the
+        # tests create, and cancelling one because a test dropped its table
+        # has crashed the whole server (a segfault in policy_retention on
+        # timescaledb:latest-pg17). Tests that need a job run it themselves.
+        run: |
+          docker exec ${{ job.services.timescaledb.id }} \
+            psql -U postgres -c "ALTER SYSTEM SET timescaledb.max_background_workers = 0"
+          docker restart ${{ job.services.timescaledb.id }}
+          until docker exec ${{ job.services.timescaledb.id }} pg_isready -U postgres -q; do sleep 1; done
+
       - name: Set up Python
         uses: actions/setup-python@v7
         with:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -379,15 +379,20 @@ git switch master && git pull --ff-only
   - GitHub Actions and `ruff`: merge once CI is green. A new `ruff` can report new findings. Fix them in the same pull request or in a separate one.
   - `pytest-homeassistant-custom-component`: **check which Home Assistant it pins first** ([section 5](#5-development-environment)). If it pins a beta, close the pull request with a comment saying so. When a release that pins a stable version exists, bump to it on a branch of your own.
 
-### 7.5 Protecting `master` (recommended)
+### 7.5 `master` is protected
 
-In GitHub → Settings → Branches, add a rule for `master`:
+`master` has a branch protection rule (GitHub → Settings → Branches), which applies to administrators too:
 
-- **Require a pull request before merging**, with 0 required approvals: a single maintainer cannot approve their own pull request.
-- **Require status checks to pass**: `Run Unit Tests`, `Upgrade from older releases`, `HACS`, `Hassfest`. CodeQL stays advisory.
-- **Block force pushes and deletions.**
+- **A pull request is required to change it**, with 0 required approvals: a single maintainer cannot approve their own pull request. A direct `git push` to `master` is refused.
+- **These checks must pass before merging**: `Run Unit Tests`, `Upgrade from older releases`, `HACS`, `Hassfest`. CodeQL stays advisory.
+- **Force pushes and deleting the branch are refused.**
+- Branches do not have to be up to date with `master` before merging.
 
-Without this rule, the workflow above is only a convention: a direct `git push` to `master` still works.
+Tags are not affected: a release is still published by pushing a tag ([section 9](#9-releasing)).
+
+A check listed as required must exist in every pull request's workflows, or that pull request waits for it forever. When adding or renaming a CI job that should be required, merge it first, then add it to the rule.
+
+**In an emergency** (CI broken by something outside the repository, and a fix must land): lift the rule temporarily in Settings → Branches, or with `gh api -X DELETE repos/jonathan-gtd/scribe/branches/master/protection`, and put it back afterwards with the settings above.
 
 ### 7.6 Fixing a released version
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -59,6 +59,7 @@ HACS installs **only `custom_components/scribe/`**. Everything else in the repos
 | `custom_components/scribe/services.yaml`, `icons.json`, `manifest.json` | Service descriptions, icons, integration manifest (holds the **version**). |
 | `tests/` | Unit tests, run against mocks. `tests/conftest.py` mocks `asyncpg.create_pool` for every test. |
 | `tests/integration/` | End-to-end tests against a real TimescaleDB. See [section 6](#6-tests). |
+| `tests/upgrade/` | Upgrade tests: a database filled by an older release, opened by the current code. See [6.6](#66-upgrade-tests). |
 | `migration/` | Stand-alone scripts that import history from InfluxDB, LTSS or the HA recorder. Not part of the integration. |
 | `scripts/` | Local helper shell scripts. See [section 15](#15-migration-scripts-and-helper-scripts). |
 | `.github/workflows/` | CI. See [section 6](#6-tests) and [section 9](#9-releasing). |
@@ -226,8 +227,9 @@ Breaking one of these has caused a real bug before. Each is explained in a comme
 |---|---|
 | `venv/bin/python -m pytest tests --ignore=tests/integration` | Unit tests only. No database needed. |
 | `venv/bin/python -m pytest tests/integration` | Integration tests. Need the TimescaleDB container ([section 1](#1-quick-start)). |
-| `venv/bin/python -m pytest tests` | Everything. Integration tests skip themselves if no database answers. |
+| `venv/bin/python -m pytest tests` | Everything. Integration and upgrade tests skip themselves if no database answers. |
 | `venv/bin/python -m pytest tests/test_collect_devices.py -k child` | One file, filtered by test name. |
+| `venv/bin/python -m pytest tests/upgrade` | Upgrade tests from older releases, one per release ([6.6](#66-upgrade-tests)). Need the TimescaleDB container. |
 | `venv/bin/ruff check . && venv/bin/ruff format --check .` | Lint and formatting, as in CI. `venv/bin/ruff format .` fixes the formatting. |
 
 **To reproduce CI exactly:**
@@ -254,7 +256,7 @@ venv/bin/ruff check . && venv/bin/ruff format --check . \
 
 | Workflow | When | What |
 |---|---|---|
-| `tests.yaml` | push to `master`, every pull request, and before each release | `ruff check`, `ruff format --check`, the whole suite against a TimescaleDB service container, **coverage ≥ 83 %**, and a second run of `tests/integration` that **fails if any integration test was skipped**. |
+| `tests.yaml` | push to `master`, every pull request, and before each release | `ruff check`, `ruff format --check`, the whole suite against a TimescaleDB service container, **coverage ≥ 83 %**, and a second run of `tests/integration` that **fails if any integration test was skipped**. A second job, `Upgrade from older releases`, runs `tests/upgrade` ([6.6](#66-upgrade-tests)) and fails if any of them was skipped; the first job leaves that folder out. |
 | `validate.yaml` | push to `master`, pull requests, daily | HACS validation and hassfest (Home Assistant's manifest and translation checks). |
 | `codeql.yaml` | push to `master`, pull requests, weekly | GitHub CodeQL security analysis. Results go to the Security tab. It does not block a merge. |
 | `upstream-watch.yaml` | Mondays, or by hand | The suite against the **latest Home Assistant pre-release**, ignoring the pin. It only runs on a schedule, so a failure sends an email and never blocks anything. |
@@ -292,6 +294,34 @@ venv/bin/python -m pytest tests --ignore=tests/integration -q \
 ```
 
 Run it with the environment from 6.4 to check an upcoming Home Assistant version. To keep a deprecation from coming back, write a test that uses the real helper (not a mock) and asserts `"deprecated" not in caplog.text`, like `tests/test_collect_devices.py`.
+
+### 6.6 Upgrade tests
+
+Every other test starts from an empty database. Existing users do not: they update with a database written by an older release. `tests/upgrade/` tests that path, with **one test per release**:
+
+```
+venv/bin/python -m pytest tests/upgrade             # every release
+venv/bin/python -m pytest tests/upgrade -k v3.8.0   # one release
+```
+
+For each release, the `older_database` fixture (`tests/upgrade/conftest.py`):
+
+1. creates a fresh database on the test server, with TimescaleDB enabled, as on a real installation;
+2. checks out the release's tag in a temporary git worktree, and runs `tests/upgrade/seed.py` there **in a separate process**, so that **the release's own code** fills the database through its normal setup: a config entry, state changes, an event, the `flush` service. It has to be another process: two versions of `custom_components.scribe` cannot be imported by the same interpreter;
+3. hands the database to `test_an_older_database_keeps_working` (`tests/upgrade/test_upgrade.py`), which runs with the **current code** and checks that Scribe:
+   - starts without being blocked and without raising an error-level Repairs issue;
+   - finds the old history through the `states` view;
+   - keeps writing to the entities the old release registered;
+   - carries the whole history through a rename;
+   - has its hypertables and compression policies;
+   - survives a restart;
+4. removes the worktree and the database afterwards.
+
+- **Releases tested**: the last patch of every stable minor since 3.2, read from the git tags by `releases()` in `conftest.py`. A new release is included automatically once it is tagged.
+- **Needs** the test TimescaleDB from [section 1](#1-quick-start), with a role that can create databases (the default `postgres` can), **and the git tags**. Without a database the tests are skipped; in a shallow clone (no tags) there is nothing to test and they are skipped too. The CI job fetches the whole history and fails on any skip.
+- `seed.py` is not named `test_*`, so pytest never collects it directly.
+- **Databases created by 3.1 to 3.5 have no primary key on `states_raw`**, and no release ever added it. On them, the test skips the check that relies on it (duplicate rows ignored with `ON CONFLICT`).
+- The old code runs on the pinned Home Assistant. If a future Home Assistant can no longer run an old release, its test fails with "`vX` could not fill the database with its own code". That is the old release failing, not a regression: raise `OLDEST` in `tests/upgrade/conftest.py` to stop testing it.
 
 ---
 
@@ -352,7 +382,7 @@ git switch master && git pull --ff-only
 In GitHub → Settings → Branches, add a rule for `master`:
 
 - **Require a pull request before merging**, with 0 required approvals: a single maintainer cannot approve their own pull request.
-- **Require status checks to pass**: `Run Unit Tests`, `HACS`, `Hassfest`. CodeQL stays advisory.
+- **Require status checks to pass**: `Run Unit Tests`, `Upgrade from older releases`, `HACS`, `Hassfest`. CodeQL stays advisory.
 - **Block force pushes and deletions.**
 
 Without this rule, the workflow above is only a convention: a direct `git push` to `master` still works.
@@ -412,7 +442,7 @@ Then bring the fix into `master` through a normal pull request (`git cherry-pick
    ```
 
 7. Follow the **Release** workflow in the Actions tab (or `gh run watch`). It:
-   1. runs the whole `tests.yaml` suite on the tagged commit;
+   1. runs the whole `tests.yaml` workflow on the tagged commit: the test suite and the upgrade tests;
    2. fails if the tag is not `v` + the version in `manifest.json`;
    3. zips `custom_components/scribe` into `scribe.zip`;
    4. creates the GitHub release with generated notes and the zip, marked as a pre-release if the tag ends in `aN`/`bN`/`rcN`.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -30,7 +30,8 @@ uv venv --python 3.14 venv
 uv pip install --python venv/bin/python -r requirements_test.txt pytest-cov
 
 docker run -d --name scribe-test-db -e POSTGRES_PASSWORD=scribe \
-    -e POSTGRES_DB=scribe -p 55432:5432 timescale/timescaledb:latest-pg17
+    -e POSTGRES_DB=scribe -p 55432:5432 timescale/timescaledb:latest-pg17 \
+    -c timescaledb.max_background_workers=0
 
 venv/bin/ruff check . && venv/bin/ruff format --check .
 venv/bin/python -m pytest tests
@@ -251,6 +252,7 @@ venv/bin/ruff check . && venv/bin/ruff format --check . \
     - Query through `writer._pool`, not a new pool: only the writer's pool has the `jsonb` codec, and without it dict attributes fail.
     - `pg_class.relkind` comes back from asyncpg as **bytes**, so `== "r"` never matches. Cast it to text in SQL.
     - The statistics coordinators are off by default. A test that needs them must enable them.
+    - **The test server runs with TimescaleDB's background jobs switched off** (`timescaledb.max_background_workers=0`, in the `docker run` of [section 1](#1-quick-start) and in every CI job). Otherwise the scheduler runs retention and compression jobs on the tables the tests create, and cancelling one because a test dropped its table has crashed the whole server: a segfault in `policy_retention` on `timescaledb:latest-pg17`. The policies still exist and can be checked. A test that needs a job to run calls it itself (`CALL run_job(...)`, `compress_chunk(...)`). For a container created without the flag: `docker exec scribe-test-db psql -U postgres -c "ALTER SYSTEM SET timescaledb.max_background_workers = 0"`, then `docker restart scribe-test-db`.
 
 ### 6.3 What CI checks
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,12 @@ as opposed to the mocked suites, which assert on the SQL that was issued.
 Start the database they expect with:
 
     docker run -d --name scribe-test-db -e POSTGRES_PASSWORD=scribe \
-        -e POSTGRES_DB=scribe -p 55432:5432 timescale/timescaledb:latest-pg17
+        -e POSTGRES_DB=scribe -p 55432:5432 timescale/timescaledb:latest-pg17 \
+        -c timescaledb.max_background_workers=0
+
+Background jobs are off so the scheduler cannot run a policy on a table a test
+is dropping: cancelling one has crashed the whole server (see
+docs/DEVELOPMENT.md, section 6.2). Tests that need a job run it themselves.
 
 Every test here skips itself when no database answers, so the suite still runs
 anywhere. CI provides a service container and fails if they skip.

--- a/tests/upgrade/conftest.py
+++ b/tests/upgrade/conftest.py
@@ -1,0 +1,148 @@
+"""Fixtures for the upgrade tests: a database filled by an older release.
+
+Every other test starts from an empty database. Existing users do not: they
+update with a database an older release wrote. For each release, the
+`older_database` fixture creates a fresh database, checks the release's tag out
+in a git worktree and runs `seed.py` there in a separate process — two versions
+of `custom_components.scribe` cannot share one interpreter — so the old code
+fills the database through its own setup path. The test then opens it with the
+current code.
+
+Needs the test TimescaleDB of docs/DEVELOPMENT.md, with a role allowed to
+create databases, and the release tags (a shallow clone has none). Skips
+otherwise; the CI job that runs these fails on a skip.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+from urllib.parse import urlsplit, urlunsplit
+
+import asyncpg
+import custom_components.scribe.writer  # noqa: F401  (patched below)
+import psycopg2
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+ADMIN_DSN = os.environ.get(
+    "SCRIBE_TEST_DSN", "postgresql://postgres:scribe@127.0.0.1:55432/scribe"
+)
+_STABLE_TAG = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+# 3.0 and 3.1 only ever shipped as betas.
+OLDEST = (3, 2)
+
+
+def releases() -> list[str]:
+    """The last patch of every stable minor since OLDEST, from the git tags.
+
+    Every database layout a user can still be on. A release joins the list as
+    soon as it is tagged.
+    """
+    try:
+        tags = subprocess.run(
+            ["git", "tag", "--list", "v*"],
+            cwd=REPO,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.split()
+    except (OSError, subprocess.CalledProcessError):
+        return []
+    latest: dict[tuple[int, int], tuple[int, str]] = {}
+    for tag in tags:
+        match = _STABLE_TAG.match(tag)
+        if not match:
+            continue
+        major, minor, patch_level = map(int, match.groups())
+        if (major, minor) < OLDEST:
+            continue
+        if (major, minor) not in latest or patch_level > latest[(major, minor)][0]:
+            latest[(major, minor)] = (patch_level, tag)
+    return [latest[key][1] for key in sorted(latest)]
+
+
+def _dsn(database: str) -> str:
+    return urlunsplit(urlsplit(ADMIN_DSN)._replace(path=f"/{database}"))
+
+
+def _admin(sql: str, database: str | None = None):
+    conn = psycopg2.connect(
+        _dsn(database) if database else ADMIN_DSN, connect_timeout=3
+    )
+    conn.autocommit = True  # CREATE / DROP DATABASE cannot run in a transaction
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+    finally:
+        conn.close()
+
+
+@pytest.fixture(autouse=True)
+def mock_create_pool():
+    """Override conftest's autouse mock: real asyncpg, minus idle timers."""
+    real = asyncpg.create_pool
+
+    def factory(*args, **kwargs):
+        kwargs.setdefault("max_inactive_connection_lifetime", 0)
+        return real(*args, **kwargs)
+
+    with patch(
+        "custom_components.scribe.writer.asyncpg.create_pool", side_effect=factory
+    ):
+        yield
+
+
+@pytest.fixture
+def older_database(release, socket_enabled, tmp_path):
+    """A fresh database, filled by `release` with its own code. Yields its DSN."""
+    try:
+        _admin("SELECT 1")
+    except psycopg2.OperationalError:
+        pytest.skip(f"no TimescaleDB at {ADMIN_DSN}")
+
+    database = "scribe_upgrade_" + re.sub(r"[^0-9a-z]", "_", release.lower())
+    _admin(f'DROP DATABASE IF EXISTS "{database}"')
+    _admin(f'CREATE DATABASE "{database}"')
+    # As on a real installation: TimescaleDB is there before Scribe starts.
+    _admin("CREATE EXTENSION IF NOT EXISTS timescaledb", database)
+
+    worktree = tmp_path / release
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", "--quiet", str(worktree), release],
+        cwd=REPO,
+        check=True,
+    )
+    try:
+        seed = worktree / "upgrade_seed" / "test_seed.py"
+        seed.parent.mkdir()
+        shutil.copy(Path(__file__).with_name("seed.py"), seed)
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "pytest", str(seed),
+                "-c", str(worktree / "pytest.ini"), "--rootdir", str(worktree),
+                "-q", "-p", "no:cacheprovider",
+            ],
+            cwd=worktree,
+            env={**os.environ, "SCRIBE_UPGRADE_DSN": _dsn(database)},
+            capture_output=True,
+            text=True,
+        )  # fmt: skip
+        if result.returncode:
+            pytest.fail(
+                f"{release} could not fill the database with its own code — the "
+                f"older release failing, not a regression; raise OLDEST in "
+                f"tests/upgrade/conftest.py if it can no longer run:\n"
+                f"{result.stdout[-3000:]}"
+            )
+        yield _dsn(database)
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(worktree)],
+            cwd=REPO,
+            check=False,
+        )
+        _admin(f'DROP DATABASE IF EXISTS "{database}" WITH (FORCE)')

--- a/tests/upgrade/seed.py
+++ b/tests/upgrade/seed.py
@@ -1,0 +1,88 @@
+"""Fill a database the way an older Scribe release does. Run by tests/upgrade/conftest.py.
+
+This file is copied into a worktree of that release and run there, so
+`custom_components.scribe` below is the *old* code. It only goes through the
+public setup path — a config entry, state changes, an event, the `flush`
+service — which every 3.x and 4.x release shares, so one seed works for all
+of them.
+
+It is deliberately not named `test_*.py`: the normal suite must not collect it.
+"""
+
+import os
+from unittest.mock import patch
+
+import asyncpg
+import custom_components.scribe.writer  # noqa: F401  (the release under test)
+import pytest
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+DSN = os.environ["SCRIBE_UPGRADE_DSN"]
+
+
+@pytest.fixture(autouse=True)
+def _custom_integrations(enable_custom_integrations):
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _real_pool():
+    """Real asyncpg, minus the idle timers Home Assistant's teardown rejects."""
+    real = asyncpg.create_pool
+
+    def factory(*args, **kwargs):
+        kwargs.setdefault("max_inactive_connection_lifetime", 0)
+        return real(*args, **kwargs)
+
+    with patch(
+        "custom_components.scribe.writer.asyncpg.create_pool", side_effect=factory
+    ):
+        yield
+
+
+# Old releases may leave a timer or a task behind at unload; that is theirs to
+# have, not something this seed is checking.
+@pytest.mark.parametrize("expected_lingering_timers", [True])
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
+async def test_seed(
+    hass, socket_enabled, expected_lingering_timers, expected_lingering_tasks
+):
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "sensor", "demo", "upgrade-temp", suggested_object_id="upgrade_temp"
+    )
+    registry.async_get_or_create(
+        "sensor", "demo", "upgrade-old", suggested_object_id="upgrade_old"
+    )
+
+    entry = MockConfigEntry(
+        domain="scribe",
+        data={"db_url": DSN, "record_states": True, "record_events": True},
+        entry_id="upgrade_entry",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    for i in range(20):
+        hass.states.async_set(
+            "sensor.upgrade_temp", str(20 + i), {"unit_of_measurement": "°C"}
+        )
+        hass.states.async_set("sensor.upgrade_old", "on" if i % 2 else "off")
+    hass.bus.async_fire("upgrade_event", {"n": 1})
+    await hass.async_block_till_done()
+    await hass.services.async_call("scribe", "flush", blocking=True)
+    await hass.async_block_till_done()
+
+    conn = await asyncpg.connect(DSN)
+    try:
+        written = await conn.fetchval(
+            "SELECT count(*) FROM states WHERE entity_id = 'sensor.upgrade_temp'"
+        )
+    finally:
+        await conn.close()
+    assert written == 20, f"the release under test wrote {written} of 20 states"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/upgrade/test_upgrade.py
+++ b/tests/upgrade/test_upgrade.py
@@ -1,0 +1,178 @@
+"""Open a database filled by an older release with the current code.
+
+One test per release, from `releases()` in conftest.py: the last patch of every
+stable minor since 3.2. The `older_database` fixture has that release fill a
+fresh database with its own code; this test then checks that the current code
+picks it up where the release left it. Run them with `pytest tests/upgrade`.
+"""
+
+import asyncpg
+import pytest
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import issue_registry as ir
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from .conftest import releases
+
+RELEASES = releases() or [
+    pytest.param(
+        None,
+        marks=pytest.mark.skip(reason="no release tags: a shallow clone has none"),
+    )
+]
+
+
+async def _fetchval(dsn, sql):
+    conn = await asyncpg.connect(dsn)
+    try:
+        return await conn.fetchval(sql)
+    finally:
+        await conn.close()
+
+
+async def _count_states(dsn, entity_id):
+    return await _fetchval(
+        dsn, f"SELECT count(*) FROM states WHERE entity_id = '{entity_id}'"
+    )
+
+
+async def _set_up(hass, dsn):
+    entry = MockConfigEntry(
+        domain="scribe",
+        data={"db_url": dsn, "record_states": True, "record_events": True},
+        entry_id="upgrade_entry",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry, hass.data["scribe"][entry.entry_id]["writer"]
+
+
+async def _flush(hass):
+    await hass.async_block_till_done()
+    await hass.services.async_call("scribe", "flush", blocking=True)
+    await hass.async_block_till_done()
+
+
+def _active_scribe_issues(hass):
+    return {
+        issue.issue_id: issue.severity
+        for (domain, _), issue in ir.async_get(hass).issues.items()
+        if domain == "scribe" and issue.active
+    }
+
+
+@pytest.mark.parametrize("release", RELEASES)
+async def test_an_older_database_keeps_working(hass, older_database):
+    dsn = older_database
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "sensor", "demo", "upgrade-temp", suggested_object_id="upgrade_temp"
+    )
+    registry.async_get_or_create(
+        "sensor", "demo", "upgrade-old", suggested_object_id="upgrade_old"
+    )
+
+    # Starts, records, and is not blocked — neither mistaken for a pre-3.0
+    # database nor stuck on a schema.
+    entry, writer = await _set_up(hass, dsn)
+    assert writer._pool is not None
+    assert writer._connected, writer._last_error
+    assert not writer._legacy_blocked, "mistaken for a pre-3.0 database"
+    assert not writer._schema_blocked
+    issues = _active_scribe_issues(hass)
+    assert not [i for i, s in issues.items() if s == ir.IssueSeverity.ERROR], issues
+
+    # The history written by the older release is there, through the view.
+    assert await _count_states(dsn, "sensor.upgrade_temp") == 20
+    assert await _count_states(dsn, "sensor.upgrade_old") == 20
+    assert (
+        await _fetchval(
+            dsn, "SELECT count(*) FROM events WHERE event_type = 'upgrade_event'"
+        )
+        == 1
+    )
+
+    # New states land on the entity the older release registered.
+    old_id = await _fetchval(
+        dsn, "SELECT id FROM entities WHERE entity_id = 'sensor.upgrade_temp'"
+    )
+    for i in range(5):
+        hass.states.async_set("sensor.upgrade_temp", str(100 + i))
+    hass.bus.async_fire("upgrade_event", {"n": 2})
+    await _flush(hass)
+    assert await _count_states(dsn, "sensor.upgrade_temp") == 25
+    assert (
+        await _fetchval(
+            dsn, "SELECT count(*) FROM events WHERE event_type = 'upgrade_event'"
+        )
+        == 2
+    )
+    assert (
+        await _fetchval(
+            dsn, "SELECT id FROM entities WHERE entity_id = 'sensor.upgrade_temp'"
+        )
+        == old_id
+    )
+
+    # A rename carries the whole history, the older release's rows included.
+    registry.async_update_entity(
+        "sensor.upgrade_temp", new_entity_id="sensor.upgrade_renamed"
+    )
+    await hass.async_block_till_done()
+    assert await _count_states(dsn, "sensor.upgrade_renamed") == 25
+    assert await _count_states(dsn, "sensor.upgrade_temp") == 0
+
+    # A batch overlapping rows already written is retried with ON CONFLICT,
+    # which needs the (metadata_id, time) primary key. Databases created by
+    # 3.1 to 3.5 do not have it — no release ever added it afterwards — so
+    # there a duplicate is simply written, as it always was on them.
+    if await _fetchval(
+        dsn,
+        "SELECT count(*) FROM pg_constraint "
+        "WHERE conrelid = 'states_raw'::regclass AND contype = 'p'",
+    ):
+        conn = await asyncpg.connect(dsn)
+        try:
+            row = await conn.fetchrow(
+                "SELECT time, metadata_id FROM states_raw ORDER BY time LIMIT 1"
+            )
+        finally:
+            await conn.close()
+        async with writer._metadata_lock:
+            await writer._copy_batch(
+                [(row["time"], row["metadata_id"], "duplicate", None, None)], []
+            )
+
+    # The storage features are in place on the older tables.
+    assert (
+        await _fetchval(
+            dsn,
+            "SELECT count(*) FROM timescaledb_information.hypertables "
+            "WHERE hypertable_name IN ('states_raw', 'events')",
+        )
+        == 2
+    )
+    assert (
+        await _fetchval(
+            dsn,
+            "SELECT count(*) FROM timescaledb_information.jobs "
+            "WHERE proc_name = 'policy_compression' "
+            "AND hypertable_name IN ('states_raw', 'events')",
+        )
+        == 2
+    )
+    assert await _fetchval(
+        dsn, "SELECT to_regclass('states_raw_meta_time_idx') IS NULL"
+    )
+
+    # And it survives a restart on the upgraded database.
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    entry, writer = await _set_up(hass, dsn)
+    assert writer._connected and not writer._legacy_blocked
+    hass.states.async_set("sensor.upgrade_renamed", "7")
+    await _flush(hass)
+    assert await _count_states(dsn, "sensor.upgrade_renamed") == 26
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()


### PR DESCRIPTION
## Why

Every test so far started from an **empty** database. Existing users don't: they update with a database written by an older release. Nothing tested that path; the old layouts were at best imitated by hand.

## What it adds: `tests/upgrade/`, one pytest test per release

```
pytest tests/upgrade             # every release
pytest tests/upgrade -k v3.8.0   # one release
```

For each release, the `older_database` fixture (`tests/upgrade/conftest.py`):
1. creates a fresh TimescaleDB database;
2. checks out the release's tag in a worktree and runs `seed.py` there **in a separate process**, so **the release's own code** fills the database (config entry, states, event, `flush`). Two versions of the integration cannot share one interpreter;
3. hands it to `test_an_older_database_keeps_working`, which runs with **the current code** and checks that Scribe is not blocked, raises no error-level Repairs issue, finds the old history, keeps writing to the same entities, carries the history through a rename, has its storage policies, and survives a restart;
4. cleans up the worktree and the database.

Releases tested: the last patch of every stable minor since 3.2, read from the tags, so a new release is included automatically. Without a database or without tags (shallow clone), the tests are skipped.

## CI

- A new `Upgrade from older releases` job runs `pytest tests/upgrade`. It checks out the full history for the tags, **fails on any skip**, and uses `set -o pipefail` so a failing test cannot be hidden by `tee`. It also gates releases through `release.yaml`.
- The main job leaves out `tests/upgrade`.
- The comment on the existing job named a test file that no longer exists; it is fixed.

## Second commit: the TimescaleDB crash in CI

The `Run Unit Tests` failures on #60 and on this PR came from a **Postgres crash**, not from Scribe. The server log shows `background worker "Retention Policy" was terminated by signal 11: Segmentation fault`. The tests' tables are dropped while TimescaleDB's scheduler is running a retention job on them. The job is cancelled and crashes the whole server (a bug in `timescaledb:latest-pg17`).

The test servers now run with `timescaledb.max_background_workers = 0`, in every CI job and in the documented `docker run`. Policies are still created and checked. Tests that need a job to run already call it themselves (`run_job`, `compress_chunk`).

## Third commit

`docs/DEVELOPMENT.md` §7.5 describes the protection on `master`, which is now in place.

## Verification (local)

- **8/8** releases pass: v3.2.4, v3.3.1, v3.4.1, v3.5.0, v3.6.3, v3.7.0, v3.8.0, v4.1.0.
- **A regression is caught**: with the pre-3.0 detection deliberately broken, the test for v3.8.0 fails.
- Without a database, all 8 are skipped. `-k v3.5.0` runs only that release.
- 160 integration tests pass, and the unit tests are unaffected.

## Finding

Databases created by **3.1 to 3.5 have no primary key on `states_raw`**, and no release ever added it. This is not a regression; it is documented in §6.6.