### PR TITLE
fix(writer): Repairs outlived the tables it was about, and Scribe itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - **Turning TLS off left the "TLS is not fully in force" repair up**: the issue describes a certificate that could not be loaded, and disabling TLS in the options makes it moot — but the entry reloads without restarting Home Assistant, and nothing retired the issue until the next restart. It now clears as soon as Scribe starts without TLS.
+- **Repairs kept warning about tables Scribe had stopped managing, and outlived Scribe itself**: an issue about the `events` or `states_raw` table — not a hypertable, never compressed, a retention policy that could not be applied — stayed up after turning off *Record events* or *Record states*, and the `states` view issue after turning states off. Saving the options reloads Scribe, and the storage checks skip a table that is no longer recorded, so nothing cleared what they had reported. Removing the integration left every one of its issues in the panel too. All of them lasted until the next Home Assistant restart. A reload now ends where a restart would — the issues about a table go with the table — and removing Scribe retires everything it raised.
 
 ## [4.1.0] - 2026-09-11
 

--- a/custom_components/scribe/__init__.py
+++ b/custom_components/scribe/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import (
     area_registry as ar,
     device_registry as dr,
     entity_registry as er,
+    issue_registry as ir,
 )
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.const import (
@@ -1045,6 +1046,20 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Retire every Repairs issue once Scribe itself is removed.
+
+    Unloading alone leaves them up: the writer that would have cleared them is
+    gone, so a card about a database Scribe no longer talks to stayed in the
+    panel until the next Home Assistant restart. Scribe is a single-entry
+    integration, so everything under its domain belongs to this entry.
+    """
+    registry = ir.async_get(hass)
+    for domain, issue_id in list(registry.issues):
+        if domain == DOMAIN:
+            ir.async_delete_issue(hass, DOMAIN, issue_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/scribe/writer.py
+++ b/custom_components/scribe/writer.py
@@ -1202,6 +1202,29 @@ class ScribeWriter:
             if enabled:
                 await create(conn)
 
+        if not self.record_states:
+            # The view is only (re)built while states are recorded. Nothing
+            # re-checks it otherwise, so an issue about it would stay up until
+            # the next restart — which would then drop it and never raise it
+            # again. A reload has to leave the panel as a restart would.
+            self._clear_issue(ISSUE_VIEW_FAILED)
+
+    def _retire_table_issues(self, table: str):
+        """Clear every issue about a table Scribe no longer manages.
+
+        Turning recording off for states or events reloads the entry, and the
+        storage checks then skip that table — so nothing would clear what they
+        said about it last time. A restart drops those issues anyway (they are
+        not persistent) and never raises them again: a reload must end up in
+        the same place.
+        """
+        for issue in (
+            ISSUE_NO_HYPERTABLE,
+            ISSUE_NO_COMPRESSION,
+            ISSUE_RETENTION_FAILED,
+        ):
+            self._clear_issue(issue.format(table=table))
+
     async def _init_hypertables(self):
         """Convert and tune each recorded table, one failure never stopping another.
 
@@ -1218,6 +1241,7 @@ class ScribeWriter:
             ),
         ):
             if not enabled:
+                self._retire_table_issues(table)
                 continue
             try:
                 await self._init_hypertable(table, segment_by, retention)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -441,15 +441,17 @@ Scribe reports conditions it cannot fix itself in Settings → System → Repair
 | `schema_failed` | `schema_failed` | error | `init_db` raised, usually missing privileges | the next successful `init_db` |
 | `schema_unavailable` | `schema_unavailable` | error | `db_schema` is not the schema actually in use | the schema check passes |
 | `legacy_schema` | `legacy_schema` | error | a pre-3.0 database is detected | the next successful `init_db` |
-| `view_failed` | `view_failed` | error | the `states` view cannot be created | the view is created |
+| `view_failed` | `view_failed` | error | the `states` view cannot be created | the view is created, or states are no longer recorded |
 | `no_timescaledb` | `no_timescaledb` | warning | the extension is missing and cannot be enabled | the extension is found |
 | `ssl_degraded` | `ssl_degraded` | warning | a configured certificate could not be loaded | the TLS context builds without problems, or TLS is turned off |
-| `no_hypertable_<table>` | `no_hypertable` | warning | TimescaleDB is installed but the table is not a hypertable | the table is a hypertable, or TimescaleDB is absent |
-| `no_compression_<table>` | `no_compression` | warning | the hypertable has no compression policy | a compression policy exists |
-| `retention_failed_<table>` | `retention_failed` | error | the retention interval is invalid, or the policy could not be applied | the policy is applied, or retention is emptied |
+| `no_hypertable_<table>` | `no_hypertable` | warning | TimescaleDB is installed but the table is not a hypertable | the table is a hypertable, or TimescaleDB is absent, or the table is no longer recorded |
+| `no_compression_<table>` | `no_compression` | warning | the hypertable has no compression policy | a compression policy exists, or the table is no longer recorded |
+| `retention_failed_<table>` | `retention_failed` | error | the retention interval is invalid, or the policy could not be applied | the policy is applied, or retention is emptied, or the table is no longer recorded |
 | `rename_collision_<entity_id>` | `rename_refused_live`, `rename_refused_unprovable` (warning), `rename_failed` (error) | see key | a rename is refused or fails | a later rename to the same `entity_id` succeeds |
 
 The checks done by `init_db` (schema, pre-3.0 database, view, TimescaleDB, hypertables, compression, retention) only run at startup, so **the issues they raise are re-checked at the next start**: a Home Assistant restart or any change in the options flow. The flush and connection issues clear themselves while Scribe is running.
+
+**A reload must leave the panel as a restart would.** Every issue is non-persistent, so a restart turns them all inactive and setup raises again whatever is still true. A reload does not: an issue stays up until something clears it. So a check that a new configuration *skips* must clear what it said last time — a table no longer recorded retires its hypertable, compression and retention issues, and turning states off retires `view_failed`. Removing Scribe retires every issue (`async_remove_entry`), since the writer that would have cleared them is gone.
 
 **Adding an issue:**
 

--- a/tests/integration/test_repairs.py
+++ b/tests/integration/test_repairs.py
@@ -303,3 +303,102 @@ async def test_dropping_data_stops_being_reported_once_writing_recovers(hass, cl
         assert get_issue(hass, ISSUE_DATA_DROPPED) is None
     finally:
         await w.stop()
+
+
+# ---------------------------------------------------------------------------
+# A reload must leave the panel as a restart would
+# ---------------------------------------------------------------------------
+#
+# Every Scribe issue is non-persistent: a restart turns them all inactive and
+# setup raises again whatever is still true. A reload — which is what saving
+# the options form does — has to end in the same place. The storage checks
+# skip a table that is no longer recorded, so without an explicit clear an
+# issue about that table outlived the setting that made it relevant.
+
+
+def _scribe_issues(hass):
+    return {
+        issue_id for (domain, issue_id) in ir.async_get(hass).issues if domain == DOMAIN
+    }
+
+
+async def _set_options(hass, entry, **changes):
+    """What saving the options form does: update, and let Scribe reload itself."""
+    hass.config_entries.async_update_entry(entry, options={**entry.options, **changes})
+    await hass.async_block_till_done()
+
+
+@pytest.mark.asyncio
+async def test_turning_events_off_retires_what_was_said_about_them(hass, scribe_entry):
+    from custom_components.scribe.const import CONF_RECORD_EVENTS, CONF_RETENTION_EVENTS
+
+    # A value only YAML can carry: the form refuses it.
+    entry, _ = await scribe_entry(**{CONF_RETENTION_EVENTS: "forever"})
+    assert get_issue(hass, "retention_failed_events") is not None
+
+    await _set_options(hass, entry, **{CONF_RECORD_EVENTS: False})
+
+    assert get_issue(hass, "retention_failed_events") is None
+
+
+@pytest.mark.asyncio
+async def test_turning_states_off_retires_the_table_and_view_issues(hass, scribe_entry):
+    from custom_components.scribe.const import CONF_RECORD_STATES, CONF_RETENTION_STATES
+    from custom_components.scribe.writer import ISSUE_VIEW_FAILED
+
+    entry, writer = await scribe_entry(**{CONF_RETENTION_STATES: "forever"})
+    # The view cannot be made to fail without breaking the database under
+    # every other test; what matters here is what clears it.
+    writer._report_issue(
+        ISSUE_VIEW_FAILED, "view_failed", {"view": "states", "error": "x"}
+    )
+    assert get_issue(hass, "retention_failed_states_raw") is not None
+
+    await _set_options(hass, entry, **{CONF_RECORD_STATES: False})
+
+    assert get_issue(hass, "retention_failed_states_raw") is None
+    assert get_issue(hass, ISSUE_VIEW_FAILED) is None
+
+
+@pytest.mark.asyncio
+async def test_turning_one_table_off_leaves_the_other_tables_issues(hass, scribe_entry):
+    """Retiring is per table: states still recorded keep their own report."""
+    from custom_components.scribe.const import (
+        CONF_RECORD_EVENTS,
+        CONF_RETENTION_EVENTS,
+        CONF_RETENTION_STATES,
+    )
+
+    entry, _ = await scribe_entry(
+        **{CONF_RETENTION_STATES: "forever", CONF_RETENTION_EVENTS: "forever"}
+    )
+
+    await _set_options(hass, entry, **{CONF_RECORD_EVENTS: False})
+
+    assert get_issue(hass, "retention_failed_events") is None
+    assert get_issue(hass, "retention_failed_states_raw") is not None
+
+
+@pytest.mark.asyncio
+async def test_removing_scribe_retires_every_issue(hass, clean_db):
+    """The writer that would clear them is gone with the integration."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.scribe.const import CONF_DB_URL, CONF_RETENTION_EVENTS
+
+    from .conftest import DSN
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_DB_URL: DSN},
+        options={CONF_RETENTION_EVENTS: "forever", "record_events": True},
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert _scribe_issues(hass), "nothing was raised, so nothing is being tested"
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert _scribe_issues(hass) == set()


### PR DESCRIPTION
Same class of bug as #61, in the places #61 doesn't cover.

**What the user saw.** An issue about the `events` or `states_raw` table (not a hypertable, never compressed, retention policy failed) stayed in Repairs after turning off *Record events* / *Record states*, and `view_failed` stayed after turning states off. Removing the integration left all of its issues in the panel too. All of them lasted until the next Home Assistant restart.

**Why.** Saving the options reloads the entry, and `_init_hypertables` skips a table that is no longer recorded, so the only code that could clear those issues never ran. On removal nothing unregisters them at all.

**The fix.** A reload should end where a restart would. Every Scribe issue is non-persistent, so a restart turns them all inactive and setup raises again only what is still true.
- A table that is no longer recorded retires its three storage issues (`_retire_table_issues`).
- Turning states off retires `view_failed`.
- `async_remove_entry` deletes every issue under the domain. Scribe is single-entry, so none of them belong to anything else.

I didn't clear everything on unload, even though that one line would also have covered #61: it would un-ignore any issue the user had dismissed, on every options change, and a restart keeps dismissals. One test checks that turning events off leaves the states table's issue alone.

**Tests.** Four new tests in `test_repairs.py` go through the real flow (options saved, Scribe reloading itself). All four fail with the source reverted. The full suite passes on HA 2026.9.1 (pinned) and on **2026.3.1**, the minimum in `hacs.json`.

**Heads-up:** #61 also creates `## [Unreleased]` in `CHANGELOG.md`, so whichever of the two merges second will get a one-line conflict. It's a trivial fix: keep both bullets under `### Fixed`.
