### PR TITLE
test(upgrade): patch asyncpg through the module, not a dotted string

### DIFF
--- a/tests/upgrade/conftest.py
+++ b/tests/upgrade/conftest.py
@@ -23,9 +23,9 @@ from unittest.mock import patch
 from urllib.parse import urlsplit, urlunsplit
 
 import asyncpg
-import custom_components.scribe.writer  # noqa: F401  (patched below)
 import psycopg2
 import pytest
+from custom_components.scribe import writer as scribe_writer
 
 REPO = Path(__file__).resolve().parents[2]
 ADMIN_DSN = os.environ.get(
@@ -90,9 +90,7 @@ def mock_create_pool():
         kwargs.setdefault("max_inactive_connection_lifetime", 0)
         return real(*args, **kwargs)
 
-    with patch(
-        "custom_components.scribe.writer.asyncpg.create_pool", side_effect=factory
-    ):
+    with patch.object(scribe_writer.asyncpg, "create_pool", side_effect=factory):
         yield
 
 

--- a/tests/upgrade/seed.py
+++ b/tests/upgrade/seed.py
@@ -13,8 +13,8 @@ import os
 from unittest.mock import patch
 
 import asyncpg
-import custom_components.scribe.writer  # noqa: F401  (the release under test)
 import pytest
+from custom_components.scribe import writer as scribe_writer
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -35,9 +35,7 @@ def _real_pool():
         kwargs.setdefault("max_inactive_connection_lifetime", 0)
         return real(*args, **kwargs)
 
-    with patch(
-        "custom_components.scribe.writer.asyncpg.create_pool", side_effect=factory
-    ):
+    with patch.object(scribe_writer.asyncpg, "create_pool", side_effect=factory):
         yield
 
 


### PR DESCRIPTION
Two CodeQL alerts (`py/unused-import`, notes) appeared on `tests/upgrade/conftest.py` and `tests/upgrade/seed.py`, both mine. The import existed only so that the dotted patch target would resolve, with a `# noqa` on it.

`from custom_components.scribe import writer as scribe_writer` + `patch.object(scribe_writer.asyncpg, "create_pool", …)` does the same thing, uses the import, drops the `noqa`, and lets the interpreter check the target instead of a string.

Tests only, no change to what HACS installs.

**Verification**: the 8 upgrade tests pass, including inside the worktrees of the older releases, where `seed.py` runs against their own code.