### PR TITLE
chore: release 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [4.1.1] - 2026-09-12
 
 ### Fixed
 - **Turning TLS off left the "TLS is not fully in force" repair up**: the issue describes a certificate that could not be loaded, and disabling TLS in the options makes it moot — but the entry reloads without restarting Home Assistant, and nothing retired the issue until the next restart. It now clears as soon as Scribe starts without TLS.

--- a/custom_components/scribe/manifest.json
+++ b/custom_components/scribe/manifest.json
@@ -14,5 +14,5 @@
         "asyncpg>=0.28.0"
     ],
     "single_config_entry": true,
-    "version": "4.1.0"
+    "version": "4.1.1"
 }


### PR DESCRIPTION
Patch release **4.1.1**: the manifest goes to `4.1.1`, and the `[Unreleased]` section becomes `[4.1.1] - 2026-09-12`.

## What it ships

Two fixes to the Repairs panel, both merged since 4.1.0:

- **#61**: turning TLS off left the "TLS is not fully in force" notification up until the next Home Assistant restart.
- **#64**: notifications about a table (not a hypertable, never compressed, retention that could not be applied) outlived turning that table's recording off, and every notification outlived removing Scribe.

No behaviour change for recording, no migration, nothing to do when updating from 4.1.0.

## Verification (local, Home Assistant 2026.9.1)

- `ruff check` and `ruff format --check` pass.
- 407 tests pass, coverage 94.7 %, integration tests included.
- The 8 upgrade tests pass, from v3.2.4 to v4.1.0.
- 0 open CodeQL alerts.