### PR TITLE
ci: test the oldest Home Assistant hacs.json claims to support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -100,6 +100,76 @@ jobs:
             exit 1
           fi
 
+  minimum:
+    name: Minimum Home Assistant
+    runs-on: ubuntu-latest
+
+    # `hacs.json` names the oldest Home Assistant Scribe claims to support, and
+    # nothing tested it: the gating job runs the pinned release and
+    # upstream-watch the newest, so a helper that only exists in a recent
+    # Home Assistant would reach the users on the floor as a crash.
+    env:
+      # The plugin release pinning the oldest Home Assistant at or above the
+      # floor in hacs.json. Both are checked against each other below.
+      FLOOR: "2026.3.0"
+      PLUGIN: "0.13.317"  # Home Assistant 2026.3.1
+
+    services:
+      timescaledb:
+        image: timescale/timescaledb:latest-pg17
+        env:
+          POSTGRES_PASSWORD: scribe
+          POSTGRES_DB: scribe
+        ports:
+          - 55432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Keep TimescaleDB's background jobs out of the tests
+        # See the comment on the job above.
+        run: |
+          docker exec ${{ job.services.timescaledb.id }} \
+            psql -U postgres -c "ALTER SYSTEM SET timescaledb.max_background_workers = 0"
+          docker restart ${{ job.services.timescaledb.id }}
+          until docker exec ${{ job.services.timescaledb.id }} pg_isready -U postgres -q; do sleep 1; done
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+          allow-prereleases: true
+
+      - name: Check the pin still matches hacs.json
+        # Raising the floor without moving the pin would leave this job testing
+        # a Home Assistant nobody supports any more.
+        run: |
+          DECLARED=$(python3 -c "import json; print(json.load(open('hacs.json'))['homeassistant'])")
+          if [ "$DECLARED" != "$FLOOR" ]; then
+            echo "::error::hacs.json requires $DECLARED, this job tests $FLOOR. Set PLUGIN to the pytest-homeassistant-custom-component release pinning the oldest Home Assistant >= $DECLARED, and FLOOR to $DECLARED."
+            exit 1
+          fi
+
+      - name: Install the oldest supported Home Assistant
+        run: |
+          python -m pip install --upgrade pip
+          grep -v '^pytest-homeassistant-custom-component' requirements_test.txt > /tmp/requirements-minimum.txt
+          pip install -r /tmp/requirements-minimum.txt "pytest-homeassistant-custom-component==$PLUGIN"
+          python -c "import homeassistant.const as c; print('Home Assistant', c.__version__)"
+
+      - name: Test against the floor
+        # tests/upgrade is left out: it runs older releases against the current
+        # code, which is a different question from the floor.
+        env:
+          SCRIBE_TEST_DSN: postgresql://postgres:scribe@127.0.0.1:55432/scribe
+        run: pytest tests --ignore=tests/upgrade -q -p no:cacheprovider
+
   upgrade:
     name: Upgrade from older releases
     runs-on: ubuntu-latest

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -258,7 +258,7 @@ venv/bin/ruff check . && venv/bin/ruff format --check . \
 
 | Workflow | When | What |
 |---|---|---|
-| `tests.yaml` | push to `master`, every pull request, and before each release | `ruff check`, `ruff format --check`, the whole suite against a TimescaleDB service container, **coverage ≥ 83 %**, and a second run of `tests/integration` that **fails if any integration test was skipped**. A second job, `Upgrade from older releases`, runs `tests/upgrade` ([6.6](#66-upgrade-tests)) and fails if any of them was skipped; the first job leaves that folder out. |
+| `tests.yaml` | push to `master`, every pull request, and before each release | `ruff check`, `ruff format --check`, the whole suite against a TimescaleDB service container, **coverage ≥ 83 %**, and a second run of `tests/integration` that **fails if any integration test was skipped**. A second job, `Minimum Home Assistant`, runs the same suite against the oldest Home Assistant `hacs.json` claims to support ([6.7](#67-testing-the-oldest-supported-home-assistant)). A third, `Upgrade from older releases`, runs `tests/upgrade` ([6.6](#66-upgrade-tests)) and fails if any of them was skipped; the first job leaves that folder out. |
 | `validate.yaml` | push to `master`, pull requests, daily | HACS validation and hassfest (Home Assistant's manifest and translation checks). |
 | `codeql.yaml` | push to `master`, pull requests, weekly | GitHub CodeQL security analysis. Results go to the Security tab. It does not block a merge. |
 | `upstream-watch.yaml` | Mondays, or by hand | The suite against the **latest Home Assistant pre-release**, ignoring the pin. It only runs on a schedule, so a failure sends an email and never blocks anything. |
@@ -324,6 +324,19 @@ For each release, the `older_database` fixture (`tests/upgrade/conftest.py`):
 - `seed.py` is not named `test_*`, so pytest never collects it directly.
 - **Databases created by 3.1 to 3.5 have no primary key on `states_raw`**, and no release ever added it. On them, the test skips the check that relies on it (duplicate rows ignored with `ON CONFLICT`).
 - The old code runs on the pinned Home Assistant. If a future Home Assistant can no longer run an old release, its test fails with "`vX` could not fill the database with its own code". That is the old release failing, not a regression: raise `OLDEST` in `tests/upgrade/conftest.py` to stop testing it.
+
+### 6.7 Testing the oldest supported Home Assistant
+
+`hacs.json` names the oldest Home Assistant Scribe claims to support. The pinned release ([section 5](#5-development-environment)) is a recent one, and upstream-watch tests the newest, so nothing here sees the floor: a helper that only exists in a recent Home Assistant passes every check and reaches the users on the floor as a crash.
+
+The `Minimum Home Assistant` CI job runs the suite (without `tests/upgrade`, a different question) against it. Two values in the job say which Home Assistant that is:
+
+- `FLOOR`, the version in `hacs.json`. The job **fails if the two stop matching**, so raising the floor cannot silently leave this job testing a Home Assistant nobody supports any more.
+- `PLUGIN`, the `pytest-homeassistant-custom-component` release pinning the oldest Home Assistant at or above the floor — today `0.13.317`, for Home Assistant 2026.3.1. Find it as in [section 5](#5-development-environment).
+
+To run it locally, build a virtual environment on that plugin release as in [6.4](#64-testing-against-another-home-assistant-version), and run `pytest tests --ignore=tests/upgrade`.
+
+**When raising the floor in `hacs.json`**: set `FLOOR` to the new version, set `PLUGIN` to the matching release, and go through [section 13](#13-home-assistant-compatibility) — that is the moment the compatibility shims listed there can go.
 
 ---
 


### PR DESCRIPTION
## Why

`hacs.json` declares **2026.3.0** as the oldest supported Home Assistant, and nothing ever ran against it: `Run Unit Tests` uses the pinned release (2026.9.1) and `upstream-watch` the newest. A helper that only exists in a recent Home Assistant would pass every check and reach the users on the floor as a crash — the same shape as #56, where behaviour differed between Home Assistant versions.

## What it adds

A `Minimum Home Assistant` job in `tests.yaml`, running the suite against the floor, with `tests/upgrade` left out (that tests older *Scribe* releases against the current code, a different question).

Two values in the job define the target:
- `FLOOR`: the version in `hacs.json` (2026.3.0). **The job fails if the two stop matching**, so raising the floor cannot silently leave this job testing a Home Assistant nobody supports any more.
- `PLUGIN`: the `pytest-homeassistant-custom-component` release pinning the oldest Home Assistant at or above the floor — `0.13.317`, for Home Assistant **2026.3.1**.

`docs/DEVELOPMENT.md` gets a §6.7 explaining it, including what to do when raising the floor (it is also the moment the compatibility shims of §13 can go).

## Verification (local)

- On Home Assistant 2026.3.1, in a separate virtual environment: **407 tests pass**.
- The guard refuses a `hacs.json` whose floor was raised without moving the pin, and accepts the current one.

## Note

I have not added this check to `master`'s required checks. It is worth watching for a few runs first; say the word and I will add it.