### PR TITLE
feat(init): record what Home Assistant had already set at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **What Home Assistant had already set when Scribe started was never recorded**: Scribe only ever recorded *changes*, through a listener registered once it is set up — and Home Assistant is well into its start by then. An entity that changed while Home Assistant was down and did not change again afterwards was simply missing from the history, which went on showing the previous value across the gap; Scribe's own connectivity sensor, set up before the listener existed, had not been recorded since the last time it changed. Scribe now registers its listener before its platforms, and records the state of everything already set, once, at startup. Almost every row that adds is one the database already holds — same entity, same timestamp — and the primary key on `(metadata_id, time)` drops it, so a restart costs nothing and only what really changed is added. The exception is a database created by Scribe 3.1 to 3.5, which has no such key (no release ever added it): there the startup states are skipped rather than duplicated at every restart, and a line in the log says so.
+
 ## [4.1.1] - 2026-09-12
 
 ### Fixed

--- a/custom_components/scribe/__init__.py
+++ b/custom_components/scribe/__init__.py
@@ -395,6 +395,80 @@ async def _refresh_coordinators(*coordinators):
             )
 
 
+def _state_row(state, exclude_attributes) -> dict:
+    """One Home Assistant state, as a queued row.
+
+    Shared by the listener and the startup snapshot so a state recorded at
+    startup is byte for byte the one the listener would have recorded — same
+    `last_updated`, which is what lets the database drop the duplicate.
+    """
+    try:
+        state_val = float(state.state)
+        state_str = None
+    except (ValueError, TypeError):
+        # Not numeric: keep the text and leave `value` NULL.
+        state_val = None
+        state_str = state.state
+
+    return {
+        "type": "state",
+        "time": state.last_updated,
+        "entity_id": state.entity_id,
+        "state": state_str,
+        "value": state_val,
+        "attributes": {
+            k: v for k, v in state.attributes.items() if k not in exclude_attributes
+        },
+    }
+
+
+def _record_current_states(hass, writer, entity_filter, exclude_attributes) -> int:
+    """Queue the state of everything Home Assistant has already set.
+
+    The listener only ever sees what changes *after* it is registered, and
+    Home Assistant is well into its start by the time Scribe is set up. An
+    entity whose state changed while Home Assistant was down, and which does
+    not change again afterwards, would never be recorded: the history would
+    show the previous value carrying on across the gap.
+
+    Almost every row this queues is already in the database — same entity,
+    same `last_updated` — and the primary key on `(metadata_id, time)` drops
+    it. Only what actually changed while Home Assistant was down survives,
+    which is the point. Without that key the writes cannot be deduplicated,
+    so the snapshot is skipped rather than duplicating the history at every
+    restart (databases created by Scribe 3.1 to 3.5).
+    """
+    if not writer.deduplicates_states:
+        _LOGGER.warning(
+            "[__init__._record_current_states] Not recording the states already "
+            "set: this database has no primary key on states_raw, so they could "
+            "not be deduplicated against what is already recorded. States are "
+            "recorded from now on, as before."
+        )
+        return 0
+
+    recorded = 0
+    for state in hass.states.async_all():
+        if not entity_filter(state.entity_id):
+            continue
+        try:
+            writer.enqueue(_state_row(state, exclude_attributes))
+            recorded += 1
+        except Exception as e:
+            _LOGGER.error(
+                "[__init__._record_current_states] Error enqueuing the current state of %s: %s (%s)",
+                state.entity_id,
+                e,
+                type(e).__name__,
+                exc_info=True,
+            )
+    _LOGGER.debug(
+        "[__init__._record_current_states] Queued %d state(s) already set at startup",
+        recorded,
+    )
+    return recorded
+
+
 def _make_state_listener(writer, entity_filter, exclude_attributes):
     """Build the state-change callback.
 
@@ -415,28 +489,7 @@ def _make_state_listener(writer, entity_filter, exclude_attributes):
             return
 
         try:
-            state_val = float(new_state.state)
-            state_str = None
-        except (ValueError, TypeError):
-            # Not numeric: keep the text and leave `value` NULL.
-            state_val = None
-            state_str = new_state.state
-
-        try:
-            writer.enqueue(
-                {
-                    "type": "state",
-                    "time": new_state.last_updated,
-                    "entity_id": entity_id,
-                    "state": state_str,
-                    "value": state_val,
-                    "attributes": {
-                        k: v
-                        for k, v in new_state.attributes.items()
-                        if k not in exclude_attributes
-                    },
-                }
-            )
+            writer.enqueue(_state_row(new_state, exclude_attributes))
         except Exception as e:
             _LOGGER.error(
                 "[__init__.handle_event] Error enqueuing state for %s (state=%r): %s (%s)",
@@ -934,13 +987,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Launch background metadata sync and coordinator refreshes
         hass.async_create_task(_async_late_setup())
 
-        # Forward setup to platforms (Sensor, Binary Sensor)
-        await hass.config_entries.async_forward_entry_setups(
-            entry, ["sensor", "binary_sensor"]
-        )
-
-        # Event listeners. Both are built outside this function: they are the
-        # hot path, and reading them here would mean reading setup as well.
+        # Event listeners first, then the platforms. Both are built outside
+        # this function: they are the hot path, and reading them here would
+        # mean reading setup as well. Forwarding the platforms first cost
+        # Scribe every state set while it waited — its own entities included,
+        # which is why the connectivity sensor was never recorded at a start.
         _LOGGER.debug(
             "[__init__.async_setup_entry] Registering event listener (record_states=%s, record_events=%s)",
             cfg.record_states,
@@ -956,11 +1007,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     ),
                 )
             )
+            # What Home Assistant had already set before this listener existed.
+            # Ordering the listener first narrows that window; it cannot close
+            # it, since Scribe is set up well into a start.
+            _record_current_states(
+                hass, writer, cfg.entity_filter, cfg.exclude_attributes
+            )
 
         if cfg.record_events:
             _register_event_listeners(
                 hass, entry, writer, cfg.include_events, cfg.exclude_events
             )
+
+        # Forward setup to platforms (Sensor, Binary Sensor)
+        await hass.config_entries.async_forward_entry_setups(
+            entry, ["sensor", "binary_sensor"]
+        )
 
         # Real-time metadata sync: keep each registry's table current as
         # Home Assistant changes it, rather than only at startup.

--- a/custom_components/scribe/writer.py
+++ b/custom_components/scribe/writer.py
@@ -560,6 +560,11 @@ class ScribeWriter:
         self._background_tasks: set[asyncio.Task] = set()
         # Resolved once per start, before the hypertable steps run.
         self._has_timescaledb = False
+        # Whether states_raw carries its (metadata_id, time) primary key, which
+        # is what drops a row already recorded. Databases created before 3.6 do
+        # not have it and no release ever added it, so the startup snapshot is
+        # skipped there rather than duplicating the history at every restart.
+        self._states_deduplicated = False
         # Set when the database predates Scribe 3.0: nothing is recorded until
         # it is converted, so there is no point queuing anything either.
         self._legacy_blocked = False
@@ -1286,6 +1291,8 @@ class ScribeWriter:
                 async with conn.transaction():
                     await self._create_tables(conn)
 
+            self._states_deduplicated = await self._states_have_primary_key()
+
             # Whether the storage features exist at all decides both what to
             # attempt below and whether a failure means anything to the user.
             self._has_timescaledb = await self._check_timescaledb_available()
@@ -1320,6 +1327,39 @@ class ScribeWriter:
                 },
                 severity=ir.IssueSeverity.ERROR,
             )
+
+    async def _states_have_primary_key(self) -> bool:
+        """Whether `states_raw` can drop a row it already holds.
+
+        The key on `(metadata_id, time)` is what makes writing a state twice
+        harmless: `COPY` fails on it and the retry passes `ON CONFLICT DO
+        NOTHING`. It is part of `CREATE TABLE` since 3.6 and no release ever
+        added it to an older table, so a database created by 3.1 to 3.5 still
+        has none — and there, writing the same state twice stores it twice.
+        """
+        if not self.record_states:
+            return False
+        try:
+            return bool(
+                await self._fetchval(
+                    "SELECT EXISTS (SELECT FROM pg_constraint "
+                    "WHERE conrelid = to_regclass($1) AND contype = 'p')",
+                    self._qualified("states_raw"),
+                )
+            )
+        except Exception as e:
+            _LOGGER.debug(
+                "[writer._states_have_primary_key] Could not check the key on "
+                "states_raw: %s (%s)",
+                e,
+                type(e).__name__,
+            )
+            return False
+
+    @property
+    def deduplicates_states(self) -> bool:
+        """True when writing a state already recorded is a no-op."""
+        return self._states_deduplicated
 
     async def _detect_legacy_schema(self, conn) -> str | None:
         """Name the pre-3.0 artifact found in the database, or None.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -85,8 +85,8 @@ Ignored by git and safe to delete: `venv/`, `.pytest_cache/`, `.ruff_cache/`, `_
    2. A `ScribeWriter` is built and `writer.start()` is awaited. `start()` **never fails because the database is down**. It starts the writer loop either way, and the loop reconnects in the background (see [3.4](#34-connection-and-reconnection)).
    3. The statistics coordinators are created, only for the sensor groups that are enabled.
    4. `_async_late_setup` is started as a background task. It pushes every registry into the database (`_sync_metadata`) and primes the coordinators. It runs in the background so a large registry cannot hit Home Assistant's bootstrap timeout.
-   5. The `sensor` and `binary_sensor` platforms are set up.
-   6. The listeners are registered: state changes (if `record_states`), events (if `record_events`), and the entity, device, area and user registries.
+   5. The listeners are registered: state changes (if `record_states`), events (if `record_events`), and the entity, device, area and user registries. **Before the platforms**, so a state set while they load is recorded as it changes rather than only in its final form.
+   6. With `record_states`, `_record_current_states` queues the state of everything Home Assistant has already set ([3.7](#37-the-states-already-set-at-startup)), then the `sensor` and `binary_sensor` platforms are set up.
    7. The writer is set to stop on `homeassistant_final_write`, **not** `homeassistant_stop`. Home Assistant runs the specific listeners of an event before the `MATCH_ALL` ones, so stopping on `homeassistant_stop` flushed before Scribe had recorded the stop event and everything emitted during shutdown.
    8. The `scribe.flush` and `scribe.query` services are registered.
    9. An update listener is added: **any change in the options flow unloads and sets up the entry again**. So every check done at startup is also done after each options change.
@@ -176,7 +176,15 @@ The names `states` and `events` come from `DEFAULT_TABLE_NAME_STATES` / `DEFAULT
   - that row belongs to an entity that is **provably gone** (its `unique_id`/`domain`/`platform` resolve to nothing in Home Assistant's registry) → its history is merged into the renamed entity and the row is deleted;
   - otherwise → the rename is **refused**, nothing is modified, and `rename_refused_live` or `rename_refused_unprovable` is raised.
 
-### 3.7 Services, sensors, diagnostics
+### 3.7 The states already set at startup
+
+The listener only ever sees what changes *after* it is registered, and Scribe is set up well into a Home Assistant start. An entity that changed while Home Assistant was down and does not change again would never be recorded: the history shows the previous value carrying on across the gap.
+
+So `_record_current_states` walks `hass.states.async_all()` at setup and queues each state that passes the filter, through the same `_state_row` the listener uses — **same `last_updated`**, which is what makes it free: the row is the one already in `states_raw` for everything that did not change, the primary key on `(metadata_id, time)` refuses it, and only what really changed is added.
+
+That key is therefore the condition. A database created by Scribe 3.1 to 3.5 has none, and no release ever added it ([6.6](#66-upgrade-tests)), so writing a state twice would store it twice: `writer.deduplicates_states` is false there, the snapshot is skipped, and a warning says why. `_states_have_primary_key` settles it once per start, in `init_db`.
+
+### 3.8 Services, sensors, diagnostics
 
 - `scribe.flush` runs a flush immediately.
 - `scribe.query` runs one SQL statement in a `READ ONLY` transaction with `statement_timeout = 120000` ms (`QUERY_TIMEOUT_MS`). The rows go through the same sanitizer as the write path, so `Decimal` and `timedelta` come back as numbers.

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -29,12 +29,23 @@ async def _flush(hass, writer):
     await writer._flush()
 
 
-async def _recorded_entities(pool):
+async def _recorded_entities(pool, *, include_scribes_own=False):
+    """The entity ids recorded, Scribe's own entities left out by default.
+
+    Scribe registers its listener before its platforms, so its own sensors are
+    recorded like any other entity. A test about filtering should not have to
+    name them.
+    """
     async with pool.acquire() as conn:
         rows = await conn.fetch(
             "SELECT DISTINCT entity_id FROM states ORDER BY entity_id"
         )
-    return [r["entity_id"] for r in rows]
+    return [
+        r["entity_id"]
+        for r in rows
+        if include_scribes_own
+        or not r["entity_id"].startswith(("sensor.scribe_", "binary_sensor.scribe_"))
+    ]
 
 
 @pytest.mark.asyncio
@@ -355,3 +366,71 @@ async def test_everything_fired_during_shutdown_is_written(hass, scribe_entry):
         )
     finally:
         await conn.close()
+
+
+async def _rows_for(pool, entity_id):
+    async with pool.acquire() as conn:
+        return await conn.fetch(
+            "SELECT time, state, value FROM states WHERE entity_id = $1 ORDER BY time",
+            entity_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_states_already_set_are_recorded_at_startup(hass, scribe_entry):
+    """The listener only sees what changes after it exists.
+
+    Home Assistant is well into its start by the time Scribe is set up, so an
+    entity that does not change again would never be recorded at all.
+    """
+    hass.states.async_set("sensor.already_there", "21.5")
+
+    entry, writer = await scribe_entry()
+    await _flush(hass, writer)
+
+    rows = await _rows_for(writer._pool, "sensor.already_there")
+    assert [r["value"] for r in rows] == [21.5]
+
+
+@pytest.mark.asyncio
+async def test_a_restart_does_not_record_the_same_state_twice(hass, scribe_entry):
+    """The snapshot re-offers states already recorded; the key must drop them.
+
+    Every row it queues carries the state's own `last_updated`, so a state that
+    did not change is the row already in `states_raw` — same (metadata_id,
+    time) — and writing it again is a no-op. Without that, every restart would
+    duplicate the whole state of the installation.
+    """
+    hass.states.async_set("sensor.unchanged", "21.5")
+    entry, writer = await scribe_entry()
+    await _flush(hass, writer)
+    assert writer.deduplicates_states
+
+    # A restart: unload, set up again on the same database, same states.
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    entry, writer = await scribe_entry()
+    await _flush(hass, writer)
+
+    rows = await _rows_for(writer._pool, "sensor.unchanged")
+    assert [r["value"] for r in rows] == [21.5], "the state was recorded twice"
+
+
+@pytest.mark.asyncio
+async def test_a_state_that_changed_while_scribe_was_down_is_recovered(
+    hass, scribe_entry
+):
+    """The whole point of the snapshot: the gap an outage leaves in a history."""
+    hass.states.async_set("sensor.moved", "1")
+    entry, writer = await scribe_entry()
+    await _flush(hass, writer)
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    hass.states.async_set("sensor.moved", "2")  # nobody is listening
+
+    entry, writer = await scribe_entry()
+    await _flush(hass, writer)
+
+    rows = await _rows_for(writer._pool, "sensor.moved")
+    assert [r["value"] for r in rows] == [1.0, 2.0]

--- a/tests/test_startup_states.py
+++ b/tests/test_startup_states.py
@@ -1,0 +1,161 @@
+"""What Home Assistant had already set when Scribe started.
+
+The listener only sees what changes after it is registered, and Scribe is set
+up well into a Home Assistant start. Two things narrow that gap: the listener
+is registered before the platforms, and the states already set are recorded
+once at setup.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.scribe import _record_current_states, _state_row
+
+
+def _writer(deduplicates=True):
+    writer = MagicMock()
+    writer.deduplicates_states = deduplicates
+    writer.enqueue = MagicMock()
+    return writer
+
+
+def _queued(writer):
+    """The states queued, by entity id. Events are queued too, and have none."""
+    return {
+        call.args[0]["entity_id"]: call.args[0]
+        for call in writer.enqueue.mock_calls
+        if call.args[0].get("type") == "state"
+    }
+
+
+async def test_every_state_already_set_is_recorded(hass):
+    """An entity that never changes again would otherwise never be recorded."""
+    hass.states.async_set("sensor.temperature", "21.5", {"unit_of_measurement": "°C"})
+    hass.states.async_set("binary_sensor.door", "on")
+    writer = _writer()
+
+    assert _record_current_states(hass, writer, lambda _: True, set()) == 2
+
+    queued = _queued(writer)
+    assert queued["sensor.temperature"]["value"] == 21.5
+    assert queued["sensor.temperature"]["state"] is None
+    assert queued["binary_sensor.door"]["state"] == "on"
+    assert queued["binary_sensor.door"]["value"] is None
+
+
+async def test_the_snapshot_carries_the_state_home_assistant_holds(hass):
+    """Same `last_updated` as the live row, which is what drops the duplicate."""
+    hass.states.async_set("sensor.temperature", "21.5", {"icon": "mdi:thermometer"})
+    state = hass.states.get("sensor.temperature")
+    writer = _writer()
+
+    _record_current_states(hass, writer, lambda _: True, {"icon"})
+
+    row = _queued(writer)["sensor.temperature"]
+    assert row["time"] == state.last_updated
+    assert row == _state_row(state, {"icon"})
+    assert "icon" not in row["attributes"]
+
+
+async def test_the_filter_applies_to_the_snapshot_too(hass):
+    """Whatever the listener would drop must not come in through the back door."""
+    hass.states.async_set("sensor.kept", "1")
+    hass.states.async_set("sensor.secret", "2")
+    writer = _writer()
+
+    recorded = _record_current_states(
+        hass, writer, lambda entity_id: entity_id != "sensor.secret", set()
+    )
+
+    assert recorded == 1
+    assert set(_queued(writer)) == {"sensor.kept"}
+
+
+async def test_a_database_that_cannot_deduplicate_gets_no_snapshot(hass, caplog):
+    """Without the key on (metadata_id, time) every restart would duplicate.
+
+    Databases created by Scribe 3.1 to 3.5 have no such key, and no release
+    ever added it.
+    """
+    hass.states.async_set("sensor.temperature", "21.5")
+    writer = _writer(deduplicates=False)
+
+    assert _record_current_states(hass, writer, lambda _: True, set()) == 0
+
+    writer.enqueue.assert_not_called()
+    assert "no primary key on states_raw" in caplog.text
+
+
+async def test_a_state_set_while_the_platforms_load_is_recorded(
+    hass, mock_config_entry
+):
+    """The listener is registered before the platforms, not after.
+
+    Forwarding the platforms first cost Scribe every state set while it waited
+    — starting with its own entities, which is how the connectivity sensor was
+    never recorded at a start.
+    """
+    from custom_components.scribe import async_setup_entry
+
+    writer = MagicMock()
+    writer.start = AsyncMock()
+    writer.stop = AsyncMock()
+    writer.deduplicates_states = True
+    writer.enable_table_devices = False
+    writer.enable_table_areas = False
+    writer.enable_table_users = False
+    writer.enable_table_integrations = False
+    writer.enqueue = MagicMock()
+
+    async def set_a_state_while_loading(entry, platforms):
+        # Twice: the snapshot alone would only ever see the second value, so
+        # this is what tells the two orders apart.
+        hass.states.async_set("sensor.set_during_platform_setup", "7")
+        hass.states.async_set("sensor.set_during_platform_setup", "8")
+
+    mock_config_entry.add_to_hass(hass)
+    with (
+        patch("custom_components.scribe.ScribeWriter", return_value=writer),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            side_effect=set_a_state_while_loading,
+        ),
+    ):
+        assert await async_setup_entry(hass, mock_config_entry)
+        await hass.async_block_till_done()
+
+    queued = [
+        call.args[0]["value"]
+        for call in writer.enqueue.mock_calls
+        if call.args[0].get("entity_id") == "sensor.set_during_platform_setup"
+    ]
+    assert queued == [7.0, 8.0], (
+        "both transitions must be recorded; with the platforms set up first "
+        "only the snapshot sees this entity, and only its last value"
+    )
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_value", "expected_state"),
+    [
+        ("21.5", 21.5, None),
+        ("-3", -3.0, None),
+        ("unavailable", None, "unavailable"),
+        ("", None, ""),
+    ],
+)
+def test_a_state_is_split_into_a_number_or_a_text(
+    state, expected_value, expected_state
+):
+    """The snapshot and the listener must not disagree on what a state is."""
+    holder = MagicMock()
+    holder.state = state
+    holder.entity_id = "sensor.x"
+    holder.attributes = {}
+
+    row = _state_row(holder, set())
+
+    assert row["value"] == expected_value
+    assert row["state"] == expected_state


### PR DESCRIPTION
## The problem, seen on a real installation

Scribe only records *changes*. Its listener sees what happens after it is registered, and Home Assistant is well into its start by then. So:

- an entity that changed **while Home Assistant was down**, and does not change again, is missing from the history, which goes on showing the previous value across the gap;
- Scribe's own entities were never recorded at a start at all: the platforms were set up **before** the listener was registered. On the maintainer's instance, `binary_sensor.scribe_database_connection` had no row since the last time it toggled, three restarts earlier.

## The fix

1. **The listeners are registered before the platforms.** A state set while they load is now recorded as it changes, not only in its final form.
2. **`_record_current_states` queues the state of everything already set**, once, at setup.

Both build their rows through the same `_state_row`, so a state recorded at startup is byte for byte the one the listener would have recorded — **same `last_updated`**.

## Why it costs nothing

For everything that did not change, the queued row **is** the row already in `states_raw`: same `(metadata_id, time)`, so the primary key refuses it and only what really changed is added.

That key is the condition. A database created by Scribe **3.1 to 3.5 has none**, and no release ever added it, so writing a state twice would store it twice. There, `writer.deduplicates_states` is false, the snapshot is skipped, and a warning explains why. `_states_have_primary_key` settles it once per start.

## Verification

Against a real TimescaleDB:
- a state already set before setup is recorded;
- **a restart does not record it twice**;
- a state changed while Scribe was down is picked up.

All three fail without the snapshot. The ordering has its own test — a state that changes twice while the platforms load must keep both transitions — which fails with the platforms back in front.

419 tests pass on Home Assistant 2026.9.1 and on 2026.3.1 (the floor in `hacs.json`), coverage 94.6 %, and the 8 upgrade tests pass.

One existing test changed: `test_excluded_entities_never_reach_the_database` now also sees Scribe's own connectivity sensor, which is the fix working. Its helper leaves Scribe's own entities out by default.