### PR TITLE
chore: release 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [4.2.0] - 2026-09-12
 
 ### Fixed
 - **What Home Assistant had already set when Scribe started was never recorded**: Scribe only ever recorded *changes*, through a listener registered once it is set up — and Home Assistant is well into its start by then. An entity that changed while Home Assistant was down and did not change again afterwards was simply missing from the history, which went on showing the previous value across the gap; Scribe's own connectivity sensor, set up before the listener existed, had not been recorded since the last time it changed. Scribe now registers its listener before its platforms, and records the state of everything already set, once, at startup. Almost every row that adds is one the database already holds — same entity, same timestamp — and the primary key on `(metadata_id, time)` drops it, so a restart costs nothing and only what really changed is added. The exception is a database created by Scribe 3.1 to 3.5, which has no such key (no release ever added it): there the startup states are skipped rather than duplicated at every restart, and a line in the log says so.

--- a/custom_components/scribe/manifest.json
+++ b/custom_components/scribe/manifest.json
@@ -14,5 +14,5 @@
         "asyncpg>=0.28.0"
     ],
     "single_config_entry": true,
-    "version": "4.1.1"
+    "version": "4.2.0"
 }


### PR DESCRIPTION
Release **4.2.0**: the manifest goes to `4.2.0`, and `[Unreleased]` becomes `[4.2.0] - 2026-09-12`.

A minor version rather than a patch: Scribe now writes rows it never wrote before — the state of everything Home Assistant has already set, once at each start.

## What it ships

**#68 — what Home Assistant had already set at startup was never recorded.** Scribe only recorded *changes*, through a listener registered once it is set up, and Home Assistant is well into its start by then. An entity that changed while Home Assistant was down and did not change again was missing from the history, which went on showing the previous value across the gap. Scribe's own entities were never recorded at a start at all, since the platforms were set up before the listener.

The listeners are now registered before the platforms, and the states already set are recorded once at setup. Almost every row that adds is already in the database (same entity, same timestamp) and the primary key drops it, so a restart costs nothing. On a database created by Scribe 3.1 to 3.5, which has no such key, the snapshot is skipped rather than duplicating the history at every restart.

## Verification (local)

- 419 tests pass, coverage 94.6 %, integration tests included.
- The 8 upgrade tests pass, v3.2.4 to v4.1.1.
- The suite also passes on Home Assistant 2026.3.1, the floor in `hacs.json` (the new `Minimum Home Assistant` job, #67, checks that in CI from now on).