### PR TITLE
ci: hold the coverage where it is, and attest what is released

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Attesting what was built, below.
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -46,6 +49,14 @@ jobs:
         run: |
           cd custom_components
           zip -r scribe.zip scribe
+
+      - name: Attest what was built
+        # Ties the published zip to this workflow, on this commit, so anyone
+        # can check the file they downloaded is the one this repository built:
+        #   gh attestation verify scribe.zip --repo jonathan-gtd/scribe
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: custom_components/scribe.zip
 
       - name: Create Release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,7 +76,7 @@ jobs:
           pytest tests --ignore=tests/upgrade \
             --cov=custom_components/scribe \
             --cov-report=term-missing \
-            --cov-fail-under=83
+            --cov-fail-under=93
 
       - name: Publish coverage summary
         if: always()

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -245,7 +245,7 @@ Breaking one of these has caused a real bug before. Each is explained in a comme
 
 ```
 venv/bin/ruff check . && venv/bin/ruff format --check . \
-  && venv/bin/python -m pytest tests --cov=custom_components/scribe --cov-report=term-missing --cov-fail-under=83
+  && venv/bin/python -m pytest tests --ignore=tests/upgrade --cov=custom_components/scribe --cov-report=term-missing --cov-fail-under=93
 ```
 
 ### 6.2 Unit tests vs integration tests
@@ -266,7 +266,7 @@ venv/bin/ruff check . && venv/bin/ruff format --check . \
 
 | Workflow | When | What |
 |---|---|---|
-| `tests.yaml` | push to `master`, every pull request, and before each release | `ruff check`, `ruff format --check`, the whole suite against a TimescaleDB service container, **coverage ≥ 83 %**, and a second run of `tests/integration` that **fails if any integration test was skipped**. A second job, `Minimum Home Assistant`, runs the same suite against the oldest Home Assistant `hacs.json` claims to support ([6.7](#67-testing-the-oldest-supported-home-assistant)). A third, `Upgrade from older releases`, runs `tests/upgrade` ([6.6](#66-upgrade-tests)) and fails if any of them was skipped; the first job leaves that folder out. |
+| `tests.yaml` | push to `master`, every pull request, and before each release | `ruff check`, `ruff format --check`, the whole suite against a TimescaleDB service container, **coverage ≥ 93 %**, and a second run of `tests/integration` that **fails if any integration test was skipped**. A second job, `Minimum Home Assistant`, runs the same suite against the oldest Home Assistant `hacs.json` claims to support ([6.7](#67-testing-the-oldest-supported-home-assistant)). A third, `Upgrade from older releases`, runs `tests/upgrade` ([6.6](#66-upgrade-tests)) and fails if any of them was skipped; the first job leaves that folder out. |
 | `validate.yaml` | push to `master`, pull requests, daily | HACS validation and hassfest (Home Assistant's manifest and translation checks). |
 | `codeql.yaml` | push to `master`, pull requests, weekly | GitHub CodeQL security analysis. Results go to the Security tab. It does not block a merge. |
 | `upstream-watch.yaml` | Mondays, or by hand | The suite against the **latest Home Assistant pre-release**, ignoring the pin. It only runs on a schedule, so a failure sends an email and never blocks anything. |
@@ -473,7 +473,8 @@ Then bring the fix into `master` through a normal pull request (`git cherry-pick
    1. runs the whole `tests.yaml` workflow on the tagged commit: the test suite and the upgrade tests;
    2. fails if the tag is not `v` + the version in `manifest.json`;
    3. zips `custom_components/scribe` into `scribe.zip`;
-   4. creates the GitHub release with generated notes and the zip, marked as a pre-release if the tag ends in `aN`/`bN`/`rcN`.
+   4. attests the zip's provenance, so anyone can check the file they downloaded is the one this repository built: `gh attestation verify scribe.zip --repo jonathan-gtd/scribe`;
+   5. creates the GitHub release with generated notes and the zip, marked as a pre-release if the tag ends in `aN`/`bN`/`rcN`.
 8. Check the release on GitHub (`gh release view vX.Y.Z`). HACS picks it up from there.
 
 **If the workflow fails before the release is created** (wrong manifest version, failing tests), delete the tag, fix the problem through a pull request, then tag again:


### PR DESCRIPTION
Two small things, both about what CI promises.

**Coverage floor: 83 % → 93 %.** The suite covers 94.6 %, so the gate allowed eleven points of silent regression. 93 leaves room for a line without hiding a real loss.

**Release provenance.** `release.yaml` now attests `scribe.zip` with `actions/attest-build-provenance`. Anyone can then check the file they downloaded came from this workflow, on this commit:

```
gh attestation verify scribe.zip --repo jonathan-gtd/scribe
```

The next release is the first to carry it.

Also fixed: the "reproduce CI exactly" command in `docs/DEVELOPMENT.md` ran `tests/upgrade`, which has its own job and needs the git tags.

**Verification**: 419 tests pass at the new floor (94.58 %).