### PR TITLE
feat(writer): scribe.purge, to delete history on purpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **`scribe.purge`, to delete history on purpose**: Scribe could only ever add. Retention drops old chunks on a schedule, and nothing removed a single entity — a sensor you renamed, a device you returned, an integration you tried for a week — or trimmed a database once without committing to a policy. The new service takes entities, an age, or both: entities alone remove them from the database entirely, their row in `entities` included; an age alone trims everything older, events too when asked. It reports how many states, events and entity rows went. Compressed history is purged as well, and the chunks stay compressed. A call that names neither is refused rather than read as "everything".
+
 ## [4.2.0] - 2026-09-12
 
 ### Fixed

--- a/README.de.md
+++ b/README.de.md
@@ -573,6 +573,35 @@ data:
 response_variable: query_result
 ```
 
+### `scribe.purge`
+Löscht aufgezeichnete Historie. **Das lässt sich nicht rückgängig machen.**
+
+**Parameter** (mindestens einer der ersten beiden ist erforderlich):
+- `entity_id`: die zu löschenden Entitäten. Ohne `keep_days` werden ihre gesamte Historie *und* ihre Zeile in der Tabelle `entities` gelöscht — zeichnet man sie erneut auf, beginnt alles von vorn.
+- `keep_days`: löscht alles, was älter ist als diese Anzahl Tage.
+- `events` (Standard `false`): löscht auch Ereignisse, die älter sind als `keep_days`. Ohne diese Angabe wird die Option ignoriert.
+
+**Gibt zurück:** wie viele Zustände, Ereignisse und Entitätszeilen gelöscht wurden.
+
+**Beispiele:**
+```yaml
+# Eine Entität vollständig aus der Datenbank entfernen
+action: scribe.purge
+data:
+  entity_id: sensor.sensor_den_ich_nicht_mehr_will
+```
+
+```yaml
+# Alles älter als zwei Jahre entfernen, Ereignisse eingeschlossen
+action: scribe.purge
+data:
+  keep_days: 730
+  events: true
+response_variable: purged
+```
+
+Komprimierte Historie wird ebenfalls gelöscht: TimescaleDB erledigt das, und die Chunks bleiben komprimiert. Für ein gleitendes Fenster, das dauerhaft gilt, nutzen Sie stattdessen die [Aufbewahrung](#aufbewahrung): eine Purge ist einmalig.
+
 ## Fehlerbehebung
 
 ### Was man zuerst ansieht

--- a/README.es.md
+++ b/README.es.md
@@ -565,6 +565,35 @@ data:
 response_variable: query_result
 ```
 
+### `scribe.purge`
+Elimina el historial registrado. **Esto no se puede deshacer.**
+
+**Parámetros** (se requiere al menos uno de los dos primeros):
+- `entity_id`: las entidades a purgar. Sin `keep_days`, se elimina todo su historial *y* su fila en la tabla `entities`; volver a registrarlas empieza de cero.
+- `keep_days`: elimina todo lo más antiguo que este número de días.
+- `events` (por defecto `false`): elimina también los eventos más antiguos que `keep_days`. Sin esa duración, se ignora.
+
+**Devuelve:** cuántos estados, eventos y filas de entidades se eliminaron.
+
+**Ejemplos:**
+```yaml
+# Retirar por completo una entidad de la base de datos
+action: scribe.purge
+data:
+  entity_id: sensor.sensor_que_ya_no_quiero
+```
+
+```yaml
+# Recortar todo lo que tenga más de dos años, eventos incluidos
+action: scribe.purge
+data:
+  keep_days: 730
+  events: true
+response_variable: purged
+```
+
+El historial comprimido también se purga: TimescaleDB se encarga y los chunks siguen comprimidos. Para una ventana deslizante que se aplique continuamente, use los ajustes de [retención](#retención): una purga es puntual.
+
 ## Solución de problemas
 
 ### Lo primero que hay que mirar

--- a/README.fr.md
+++ b/README.fr.md
@@ -569,6 +569,35 @@ data:
 response_variable: query_result
 ```
 
+### `scribe.purge`
+Supprime l'historique enregistré. **C'est irréversible.**
+
+**Paramètres** (au moins un des deux premiers est requis) :
+- `entity_id` : les entités à purger. Sans `keep_days`, tout leur historique *et* leur ligne dans la table `entities` sont supprimés — les réenregistrer repart de zéro.
+- `keep_days` : supprime tout ce qui est plus ancien que ce nombre de jours.
+- `events` (par défaut `false`) : supprime aussi les événements plus anciens que `keep_days`. Sans cette durée, l'option est ignorée.
+
+**Retourne :** le nombre d'états, d'événements et de lignes d'entités supprimés.
+
+**Exemples :**
+```yaml
+# Retirer complètement une entité de la base
+action: scribe.purge
+data:
+  entity_id: sensor.capteur_dont_je_ne_veux_plus
+```
+
+```yaml
+# Élaguer tout ce qui a plus de deux ans, événements compris
+action: scribe.purge
+data:
+  keep_days: 730
+  events: true
+response_variable: purged
+```
+
+L'historique compressé est purgé lui aussi : TimescaleDB s'en charge et les chunks restent compressés. Pour une fenêtre glissante appliquée en continu, utilisez plutôt les réglages de [rétention](#rétention) : une purge est ponctuelle.
+
 ## Dépannage
 
 ### À regarder en premier

--- a/README.md
+++ b/README.md
@@ -552,6 +552,35 @@ data:
 response_variable: query_result
 ```
 
+### `scribe.purge`
+Delete recorded history. **This cannot be undone.**
+
+**Parameters** (at least one of the first two is required):
+- `entity_id`: entities to purge. Without `keep_days`, their whole history *and* their row in the `entities` table are deleted — recording them again starts from nothing.
+- `keep_days`: delete everything older than this many days.
+- `events` (default `false`): also delete events older than `keep_days`. Ignored without it.
+
+**Returns:** how many states, events and entity rows were deleted.
+
+**Examples:**
+```yaml
+# Remove one entity from the database entirely
+action: scribe.purge
+data:
+  entity_id: sensor.sensor_i_no_longer_want
+```
+
+```yaml
+# Trim everything older than two years, events included
+action: scribe.purge
+data:
+  keep_days: 730
+  events: true
+response_variable: purged
+```
+
+Compressed history is purged as well; TimescaleDB handles it, and the chunks stay compressed. For a rolling window you want to keep applying, use the [retention](#retention) settings instead: a purge is a one-off.
+
 ## Troubleshooting
 
 ### Before anything else

--- a/custom_components/scribe/__init__.py
+++ b/custom_components/scribe/__init__.py
@@ -752,7 +752,59 @@ def _register_services(hass, writer):
             )
             raise HomeAssistantError(f"Query failed: {e} ({type(e).__name__})")
 
+    async def handle_purge(call):
+        """Delete history, on purpose and only what was asked for."""
+        entity_ids = call.data.get("entity_id")
+        if isinstance(entity_ids, str):
+            entity_ids = [entity_ids]
+        keep_days = call.data.get("keep_days")
+
+        _LOGGER.warning(
+            "[__init__.handle_purge] Purge requested (entity_id=%s, keep_days=%s, events=%s)",
+            entity_ids or "all",
+            keep_days,
+            call.data.get("events", False),
+        )
+        try:
+            return await writer.purge(
+                entity_ids=entity_ids,
+                keep_days=keep_days,
+                include_events=bool(call.data.get("events", False)),
+            )
+        except ValueError as e:
+            # Nothing was deleted: the call did not say what to delete.
+            raise HomeAssistantError(str(e))
+        except Exception as e:
+            _LOGGER.error(
+                "[__init__.handle_purge] Purge failed: %s (%s)",
+                e,
+                type(e).__name__,
+                exc_info=True,
+            )
+            raise HomeAssistantError(f"Purge failed: {e} ({type(e).__name__})")
+
     hass.services.async_register(DOMAIN, "flush", handle_flush)
+    hass.services.async_register(
+        DOMAIN,
+        "purge",
+        handle_purge,
+        # At least one of the two, so an empty call cannot delete a history:
+        # `entity_id` alone removes those entities, `keep_days` alone trims
+        # everything older, and together they trim those entities.
+        schema=vol.All(
+            vol.Schema(
+                {
+                    vol.Optional("entity_id"): cv.entity_ids,
+                    vol.Optional("keep_days"): vol.All(
+                        vol.Coerce(int), vol.Range(min=0)
+                    ),
+                    vol.Optional("events"): cv.boolean,
+                }
+            ),
+            cv.has_at_least_one_key("entity_id", "keep_days"),
+        ),
+        supports_response=True,
+    )
     hass.services.async_register(
         DOMAIN,
         "query",

--- a/custom_components/scribe/services.yaml
+++ b/custom_components/scribe/services.yaml
@@ -13,3 +13,40 @@ query:
       selector:
         text:
           multiline: true
+
+purge:
+  name: Purge History
+  description: >-
+    Delete recorded history. Give entities to remove them from the database,
+    an age to trim everything older, or both to trim those entities. This
+    cannot be undone.
+  fields:
+    entity_id:
+      name: Entities
+      description: >-
+        Entities to purge. Without an age, their whole history and their row in
+        the entities table are deleted; recording them again starts from
+        nothing.
+      required: false
+      selector:
+        entity:
+          multiple: true
+    keep_days:
+      name: Keep days
+      description: >-
+        Delete anything older than this many days. 0 deletes everything.
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 3650
+          mode: box
+          unit_of_measurement: days
+    events:
+      name: Events too
+      description: >-
+        Also delete events older than the age given. Ignored when no age is given.
+      required: false
+      default: false
+      selector:
+        boolean:

--- a/custom_components/scribe/writer.py
+++ b/custom_components/scribe/writer.py
@@ -22,7 +22,7 @@ import dataclasses
 import json
 import math
 import uuid
-from datetime import date, datetime as dt_datetime, timedelta
+from datetime import UTC, date, datetime as dt_datetime, timedelta
 from decimal import Decimal
 
 import asyncpg
@@ -2947,6 +2947,115 @@ class ScribeWriter:
                 old_entity_id,
             )
         return merge_reason, merged_orphan_rows, dropped_duplicate_rows
+
+    # ------------------------------------------------------------------
+    # Purge
+    # ------------------------------------------------------------------
+
+    async def purge(
+        self,
+        entity_ids: list[str] | None = None,
+        keep_days: int | None = None,
+        include_events: bool = False,
+    ) -> dict[str, int]:
+        """Delete history, and report how much of it went.
+
+        Three shapes, and nothing else deletes anything:
+
+        - entities, with no age: their whole history and their `entities` row,
+          so the entity leaves the database entirely. Recording it again
+          recreates the row, with a new id and no past.
+        - entities, with an age: those entities, older than that.
+        - an age alone: everything older than that, events too when asked.
+
+        Deleting inside a compressed chunk is TimescaleDB's business and it
+        handles it; the rows go, the chunk stays compressed.
+        """
+        if not self._pool:
+            raise RuntimeError("Database not connected")
+        if not entity_ids and keep_days is None:
+            raise ValueError("purge needs entity_id, keep_days, or both")
+
+        cutoff = (
+            None
+            if keep_days is None
+            else dt_datetime.now(tz=UTC) - timedelta(days=keep_days)
+        )
+        purged = {"states": 0, "events": 0, "entities": 0}
+
+        # Held for the same reason a rename holds it: a flush resolving
+        # entity_ids must not meet a half-deleted `entities`.
+        async with self._metadata_lock:
+            async with self._pool.acquire() as conn:
+                async with conn.transaction():
+                    if entity_ids:
+                        rows = await conn.fetch(
+                            "SELECT id, entity_id FROM entities WHERE entity_id = ANY($1)",
+                            entity_ids,
+                        )
+                        ids = [row["id"] for row in rows]
+                        if not ids:
+                            _LOGGER.warning(
+                                "[writer.purge] None of %s is recorded; nothing to purge",
+                                entity_ids,
+                            )
+                            return purged
+
+                        if cutoff is None:
+                            purged["states"] = _affected_rows(
+                                await conn.execute(
+                                    "DELETE FROM states_raw WHERE metadata_id = ANY($1)",
+                                    ids,
+                                )
+                            )
+                            purged["entities"] = _affected_rows(
+                                await conn.execute(
+                                    "DELETE FROM entities WHERE id = ANY($1)", ids
+                                )
+                            )
+                        else:
+                            purged["states"] = _affected_rows(
+                                await conn.execute(
+                                    "DELETE FROM states_raw "
+                                    "WHERE metadata_id = ANY($1) AND time < $2",
+                                    ids,
+                                    cutoff,
+                                )
+                            )
+
+                        for row in rows:
+                            # Whatever was deleted, the cache must not keep
+                            # pointing at an id that may no longer exist.
+                            metadata_id = self._entity_id_map.pop(
+                                row["entity_id"], None
+                            )
+                            if metadata_id is not None:
+                                self._metadata_id_map.pop(metadata_id, None)
+                    else:
+                        purged["states"] = _affected_rows(
+                            await conn.execute(
+                                "DELETE FROM states_raw WHERE time < $1", cutoff
+                            )
+                        )
+
+                    if include_events and cutoff is not None:
+                        purged["events"] = _affected_rows(
+                            await conn.execute(
+                                f"DELETE FROM {self.table_name_events} WHERE time < $1",
+                                cutoff,
+                            )
+                        )
+
+        _LOGGER.warning(
+            "[writer.purge] Deleted %d state(s), %d event(s) and %d entity row(s) "
+            "(entities=%s, keep_days=%s)",
+            purged["states"],
+            purged["events"],
+            purged["entities"],
+            entity_ids or "all",
+            keep_days,
+        )
+        return purged
 
     async def rename_entity(self, old_entity_id: str, new_entity_id: str):
         """Rename an entity in the database (metadata only).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -187,6 +187,7 @@ That key is therefore the condition. A database created by Scribe 3.1 to 3.5 has
 ### 3.8 Services, sensors, diagnostics
 
 - `scribe.flush` runs a flush immediately.
+- `scribe.purge` deletes history: entities (with their `entities` row), everything older than an age, or those entities older than that age. It reports what went. The service schema requires `entity_id` or `keep_days` — `cv.has_at_least_one_key` — so an empty call cannot be read as "everything", and `writer.purge` refuses the same call again on its own. It takes `_metadata_lock`, like a rename: a flush resolving entity_ids must not meet a half-deleted `entities`.
 - `scribe.query` runs one SQL statement in a `READ ONLY` transaction with `statement_timeout = 120000` ms (`QUERY_TIMEOUT_MS`). The rows go through the same sanitizer as the write path, so `Decimal` and `timedelta` come back as numbers.
 - The sensors are opt-in: `enable_stats_io` (read from the writer's counters), `enable_stats_chunk` and `enable_stats_size` (each polled by its own coordinator, every 60 minutes by default).
 - Diagnostics and system health read the writer's internal state. They never show the database URL, only `_safe_target()`, which is host, port and database name.

--- a/tests/integration/test_purge.py
+++ b/tests/integration/test_purge.py
@@ -1,0 +1,176 @@
+"""Deleting history, against a real TimescaleDB.
+
+A purge is the one thing Scribe does that cannot be undone, so what matters
+here is as much what it leaves alone as what it removes.
+"""
+
+import pytest
+
+from custom_components.scribe.writer import ScribeWriter
+
+from .conftest import BASE_TIME, write_states
+
+
+async def _entity_rows(pool, entity_id):
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "SELECT count(*) FROM states WHERE entity_id = $1", entity_id
+        )
+
+
+async def _entities(pool):
+    async with pool.acquire() as conn:
+        rows = await conn.fetch("SELECT entity_id FROM entities ORDER BY entity_id")
+    return [row["entity_id"] for row in rows]
+
+
+@pytest.mark.asyncio
+async def test_purging_an_entity_removes_it_from_the_database(
+    hass, writer: ScribeWriter
+):
+    """Its history and its row: the entity leaves, not just its states."""
+    await write_states(writer, "sensor.gone", 5)
+    await write_states(writer, "sensor.kept", 5)
+
+    purged = await writer.purge(entity_ids=["sensor.gone"])
+
+    assert purged == {"states": 5, "events": 0, "entities": 1}
+    assert await _entity_rows(writer._pool, "sensor.gone") == 0
+    assert await _entity_rows(writer._pool, "sensor.kept") == 5
+    assert await _entities(writer._pool) == ["sensor.kept"]
+
+
+@pytest.mark.asyncio
+async def test_purging_an_entity_leaves_the_cache_consistent(
+    hass, writer: ScribeWriter
+):
+    """Recording it again must not write states against a deleted id."""
+    await write_states(writer, "sensor.again", 3)
+    old_id = writer._entity_id_map["sensor.again"]
+
+    await writer.purge(entity_ids=["sensor.again"])
+    assert "sensor.again" not in writer._entity_id_map
+
+    await write_states(writer, "sensor.again", 2)
+
+    assert writer._entity_id_map["sensor.again"] != old_id
+    assert await _entity_rows(writer._pool, "sensor.again") == 2
+
+
+@pytest.mark.asyncio
+async def test_an_age_trims_the_old_and_keeps_the_rest(hass, writer: ScribeWriter):
+    """`keep_days` is a horizon, not a list: everything older goes."""
+    from datetime import timedelta
+
+    from .conftest import DSN
+    import asyncpg
+
+    await write_states(writer, "sensor.long_lived", 3)
+    # The helper writes around BASE_TIME, which is itself weeks in the past, so
+    # the horizon below has to clear it: 60 days keeps those three and drops the
+    # three written 40 days before them.
+    conn = await asyncpg.connect(DSN)
+    try:
+        metadata_id = writer._entity_id_map["sensor.long_lived"]
+        await conn.executemany(
+            "INSERT INTO states_raw (time, metadata_id, state) VALUES ($1, $2, 'old')",
+            [
+                (
+                    BASE_TIME - timedelta(days=40 + i),
+                    metadata_id,
+                )
+                for i in range(3)
+            ],
+        )
+    finally:
+        await conn.close()
+    assert await _entity_rows(writer._pool, "sensor.long_lived") == 6
+
+    purged = await writer.purge(keep_days=60)
+
+    assert purged["states"] == 3
+    assert await _entity_rows(writer._pool, "sensor.long_lived") == 3
+    assert await _entities(writer._pool) == ["sensor.long_lived"], "the entity stays"
+
+
+@pytest.mark.asyncio
+async def test_events_are_only_purged_when_asked(hass, writer: ScribeWriter):
+    from datetime import timedelta
+
+    import asyncpg
+
+    from .conftest import DSN
+
+    conn = await asyncpg.connect(DSN)
+    try:
+        await conn.execute(
+            "INSERT INTO events (time, event_type) VALUES ($1, 'old_event')",
+            BASE_TIME - timedelta(days=90),
+        )
+    finally:
+        await conn.close()
+
+    kept = await writer.purge(keep_days=30)
+    assert kept["events"] == 0, "events are not touched unless asked for"
+
+    purged = await writer.purge(keep_days=30, include_events=True)
+    assert purged["events"] == 1
+
+
+@pytest.mark.asyncio
+async def test_purging_compressed_history_works(hass, writer: ScribeWriter):
+    """Most of a real history is compressed; a purge that stopped there is useless."""
+    from datetime import timedelta
+
+    import asyncpg
+
+    from .conftest import DSN
+
+    await write_states(writer, "sensor.compressed", 1)
+    metadata_id = writer._entity_id_map["sensor.compressed"]
+
+    conn = await asyncpg.connect(DSN)
+    try:
+        await conn.executemany(
+            "INSERT INTO states_raw (time, metadata_id, value) VALUES ($1, $2, 1)",
+            [
+                (BASE_TIME - timedelta(days=100, minutes=i), metadata_id)
+                for i in range(20)
+            ],
+        )
+        compressed = await conn.fetch(
+            "SELECT compress_chunk(c) FROM show_chunks('states_raw', "
+            "older_than => $1::timestamptz) c",
+            BASE_TIME - timedelta(days=90),
+        )
+        assert compressed, "nothing was compressed, so this proves nothing"
+    finally:
+        await conn.close()
+
+    purged = await writer.purge(entity_ids=["sensor.compressed"])
+
+    assert purged["states"] == 21
+    assert await _entity_rows(writer._pool, "sensor.compressed") == 0
+
+
+@pytest.mark.asyncio
+async def test_a_purge_that_names_nothing_is_refused(hass, writer: ScribeWriter):
+    """An empty call must not mean "everything"."""
+    await write_states(writer, "sensor.safe", 3)
+
+    with pytest.raises(ValueError):
+        await writer.purge()
+
+    assert await _entity_rows(writer._pool, "sensor.safe") == 3
+
+
+@pytest.mark.asyncio
+async def test_purging_an_entity_nobody_recorded_changes_nothing(
+    hass, writer: ScribeWriter
+):
+    await write_states(writer, "sensor.real", 4)
+
+    purged = await writer.purge(entity_ids=["sensor.never_seen"])
+
+    assert purged == {"states": 0, "events": 0, "entities": 0}
+    assert await _entity_rows(writer._pool, "sensor.real") == 4


### PR DESCRIPTION
Scribe could only ever add. Retention drops old chunks on a schedule; nothing could remove **one entity** — a sensor you renamed, a device you returned, an integration you tried for a week — or trim a database **once** without committing to a policy.

## `scribe.purge`

| Call | What it deletes |
| --- | --- |
| `entity_id` | those entities entirely: their history *and* their row in `entities` |
| `keep_days` | everything older than that, `events: true` to include events |
| both | those entities, older than that |
| neither | **refused** |

It returns how many states, events and entity rows went.

The refusal is in two places: the service schema (`cv.has_at_least_one_key`) and `writer.purge` itself. An empty purge must never be read as "everything".

## Details that matter

- **Compressed history is purged too.** TimescaleDB deletes inside a compressed chunk, and the chunk stays compressed. Checked against a real compressed chunk — a purge that stopped at compression would be useless on any real database.
- `writer.purge` holds `_metadata_lock`, like a rename: a flush resolving entity ids must not meet a half-deleted `entities`.
- It drops the cache entries of what it deleted, so recording a purged entity again registers it afresh instead of writing against an id that no longer exists.

## Verification

Seven integration tests against a real TimescaleDB, as much about what a purge leaves alone as what it removes: another entity's history, events nobody asked to delete, an entity nobody ever recorded, and a call naming nothing.

426 tests pass, coverage 94 %. Documented in the four READMEs and in `docs/DEVELOPMENT.md`.