### PR TITLE
chore: release 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [4.3.0] - 2026-09-12
 
 ### Added
 - **Hourly and daily summaries, kept up to date by TimescaleDB (`enable_rollups`)**: a year of a sensor reporting every 30 seconds is about a million rows, and a chart of that year reads every one of them, every time it is drawn. Turning this on adds two views — `states_hourly` and `states_daily`, each with the average, minimum, maximum and number of states per entity and per bucket — maintained incrementally by the database as states arrive, so a chart over years reads thousands of rows instead of millions. They are derived data and Scribe owns them: turning the option off deletes both, turning it back on rebuilds them from the history, and the history itself is never touched. Off by default. Only numeric states are summarised. If the database refuses to create them, a Repairs notification says so and recording carries on regardless.

--- a/custom_components/scribe/manifest.json
+++ b/custom_components/scribe/manifest.json
@@ -14,5 +14,5 @@
         "asyncpg>=0.28.0"
     ],
     "single_config_entry": true,
-    "version": "4.2.0"
+    "version": "4.3.0"
 }


### PR DESCRIPTION
Release **4.3.0**: manifest to `4.3.0`, `[Unreleased]` becomes `[4.3.0] - 2026-09-12`.

A minor version: two things Scribe could not do before.

## What it ships

- **`scribe.purge`** (#73): delete history on purpose — entities (with their row in `entities`), everything older than an age, or those entities older than that age. It reports what went, works on compressed history, and refuses a call that names neither.
- **Hourly and daily summaries** (#74, `enable_rollups`, off by default): two continuous aggregates maintained by TimescaleDB, so a chart over years reads thousands of rows instead of millions. Derived data Scribe owns: turning the option off drops them, turning it on rebuilds them, and the history is never touched.

Also since 4.2.0: the coverage floor moved from 83 % to 93 %, releases now carry a build provenance attestation, the documentation is published as a site, and CI runs the suite against the oldest Home Assistant `hacs.json` claims to support.

## Verification (local)

- 433 tests pass, coverage 93.9 %, integration tests included.
- The suite also passes on Home Assistant 2026.3.1, the floor.
- The 9 upgrade tests pass, v3.2.4 to v4.2.0.