### PR TITLE
fix(query): bound what a query can cost, and prove what it cannot do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- **`scribe.query` cannot take Home Assistant down with it**: the ceiling on a query was two minutes, and there was no ceiling at all on what it could return — `SELECT * FROM states` over a year is tens of millions of rows, loaded into Home Assistant's memory before anything could be done with them. A query now has **60 seconds** and **10 000 rows**; past either, it is refused, and the message says what to do about it (narrow it, group it with `time_bucket()`, add a `LIMIT`). The rows are streamed and counted as they arrive, so a runaway query is stopped rather than held in full and then rejected. Writing is still refused by the read-only transaction the query runs in, which is now covered by tests: `UPDATE`, `DELETE`, `TRUNCATE`, `DROP`, `INSERT`, `CREATE`, `ALTER`, `GRANT`, and two statements in one string.
+
 ## [4.3.0] - 2026-09-12
 
 ### Added

--- a/custom_components/scribe/writer.py
+++ b/custom_components/scribe/writer.py
@@ -227,7 +227,14 @@ RECONNECT_MAX_DELAY = 300
 # Ceiling for the `scribe.query` service, in milliseconds. Long enough for a
 # genuine report over a year of history, short enough that a runaway query
 # cannot hold a pooled connection and hammer the server indefinitely.
-QUERY_TIMEOUT_MS = 120_000
+QUERY_TIMEOUT_MS = 60_000
+
+# How many rows the service will hand back. A query is written by a person and
+# answered into Home Assistant's memory: `SELECT * FROM states` over a year is
+# tens of millions of rows, and loading them would take the whole process down
+# long before anything got drawn. Past this the query is refused, with what to
+# do about it, rather than truncated into a wrong answer.
+QUERY_MAX_ROWS = 10_000
 
 
 def _json_default(obj):
@@ -3454,7 +3461,18 @@ class ScribeWriter:
                     await conn.execute(
                         f"SET LOCAL statement_timeout = {QUERY_TIMEOUT_MS}"
                     )
-                    rows = await conn.fetch(sql)
+                    # Streamed, and one row past the ceiling: a query that
+                    # returns too much must not be held in memory in full
+                    # before being refused.
+                    rows = []
+                    async for row in conn.cursor(sql):
+                        rows.append(row)
+                        if len(rows) > QUERY_MAX_ROWS:
+                            raise ValueError(
+                                f"the query returns more than {QUERY_MAX_ROWS} rows; "
+                                "narrow it with a WHERE, group it with "
+                                "time_bucket(), or add a LIMIT"
+                            )
                     # Through the same sanitizer the write path uses: a query
                     # can select any type at all, and the result becomes a
                     # service response Home Assistant has to serialize.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,24 @@ def mock_db_connection():
     mock_conn.fetchrow = AsyncMock()
     mock_conn.fetch = AsyncMock()
 
+    # `scribe.query` streams its rows through a cursor rather than fetching
+    # them all, so the mock has to be iterable with `async for`. Tests set the
+    # rows through `mock_conn.fetch.return_value`, as they always did.
+    class _Cursor:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def __aiter__(self):
+            async def rows():
+                for row in self._rows or []:
+                    yield row
+
+            return rows()
+
+    mock_conn.cursor = MagicMock(
+        side_effect=lambda *args, **kwargs: _Cursor(mock_conn.fetch.return_value)
+    )
+
     # transaction() returns an async context manager
     tx_mock = AsyncMock()
     mock_conn.transaction = MagicMock(return_value=tx_mock)

--- a/tests/integration/test_query_readonly.py
+++ b/tests/integration/test_query_readonly.py
@@ -1,0 +1,119 @@
+"""What `scribe.query` refuses, against a real PostgreSQL.
+
+The service takes SQL as written — no keyword filtering, which would be a
+denylist to keep up with — and runs it in a `READ ONLY` transaction with a
+statement timeout. That is the whole protection, so it is worth proving.
+"""
+
+import asyncpg
+import pytest
+
+from .conftest import write_states
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "UPDATE entities SET entity_id = 'hacked' WHERE true",
+        "DELETE FROM states_raw WHERE true",
+        "TRUNCATE states_raw",
+        "DROP TABLE entities",
+        "INSERT INTO entities (entity_id) VALUES ('sneaked_in')",
+        "CREATE TABLE mine (id int)",
+        "ALTER TABLE entities ADD COLUMN mine int",
+        "CREATE INDEX mine ON states_raw (time)",
+        "GRANT ALL ON entities TO PUBLIC",
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_query_that_writes_is_refused(writer, sql):
+    await write_states(writer, "sensor.untouched", 3)
+
+    with pytest.raises(asyncpg.PostgresError) as raised:
+        await writer.query(sql)
+
+    assert "read-only transaction" in str(raised.value).lower(), str(raised.value)
+
+    # And the database is exactly as it was.
+    async with writer._pool.acquire() as conn:
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM states WHERE entity_id = 'sensor.untouched'"
+            )
+            == 3
+        )
+        assert await conn.fetchval("SELECT to_regclass('entities') IS NOT NULL"), (
+            "the table is still there"
+        )
+
+
+@pytest.mark.asyncio
+async def test_reading_is_allowed(writer):
+    """The point of the service: a SELECT still works."""
+    await write_states(writer, "sensor.readable", 2)
+
+    rows = await writer.query(
+        "SELECT entity_id, value FROM states WHERE entity_id = 'sensor.readable'"
+    )
+
+    assert [row["value"] for row in rows] == [0.0, 1.0]
+
+
+@pytest.mark.asyncio
+async def test_a_query_cannot_hold_a_connection_for_ever(writer, monkeypatch):
+    """The server ends it, not the caller giving up."""
+    import custom_components.scribe.writer as writer_module
+
+    monkeypatch.setattr(writer_module, "QUERY_TIMEOUT_MS", 300)
+
+    with pytest.raises(asyncpg.PostgresError) as raised:
+        await writer.query("SELECT pg_sleep(30)")
+
+    assert "statement timeout" in str(raised.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_two_statements_in_one_query_are_refused(writer):
+    """Stacking a write behind a SELECT does not even reach the transaction.
+
+    The query is sent through the extended protocol, which takes one statement
+    and no more — so `SELECT 1; DELETE …` is refused by the driver, before the
+    read-only transaction would have refused it anyway.
+    """
+    await write_states(writer, "sensor.safe", 3)
+
+    with pytest.raises(asyncpg.PostgresError) as raised:
+        await writer.query("SELECT 1; DELETE FROM states_raw WHERE true")
+
+    assert "multiple commands" in str(raised.value).lower(), str(raised.value)
+
+    async with writer._pool.acquire() as conn:
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM states WHERE entity_id = 'sensor.safe'"
+            )
+            == 3
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_query_returning_too_much_is_refused(writer, monkeypatch):
+    """Millions of rows would reach Home Assistant's memory, not a chart.
+
+    The refusal says what to do about it, and the query is stopped while it
+    streams rather than after everything has been loaded.
+    """
+    import custom_components.scribe.writer as writer_module
+
+    monkeypatch.setattr(writer_module, "QUERY_MAX_ROWS", 50)
+
+    with pytest.raises(ValueError) as raised:
+        await writer.query("SELECT generate_series(1, 5000) AS n")
+
+    message = str(raised.value)
+    assert "more than 50 rows" in message
+    assert "time_bucket()" in message and "LIMIT" in message
+
+    # And what fits still comes back.
+    rows = await writer.query("SELECT generate_series(1, 10) AS n")
+    assert len(rows) == 10

--- a/tests/test_query_service.py
+++ b/tests/test_query_service.py
@@ -40,7 +40,7 @@ async def test_query_select_valid(writer, mock_db_connection):
     assert len(result) == 1
     assert result[0]["id"] == 1
     assert result[0]["name"] == "test"
-    assert mock_db_connection.fetch.called
+    mock_db_connection.cursor.assert_called_once_with("SELECT * FROM states")
 
 
 @pytest.mark.asyncio
@@ -64,18 +64,18 @@ async def test_ensure_read_only_transaction(writer, mock_db_connection):
 
 @pytest.mark.asyncio
 async def test_query_whitespace(writer, mock_db_connection):
-    """Test query with leading whitespace."""
+    """The query reaches the database as it was written."""
     mock_db_connection.fetch.return_value = []
     await writer.query("  SELECT * FROM states")
-    assert mock_db_connection.fetch.called
+    mock_db_connection.cursor.assert_called_once_with("  SELECT * FROM states")
 
 
 @pytest.mark.asyncio
 async def test_query_case_insensitive(writer, mock_db_connection):
-    """Test query case insensitivity."""
+    """Nothing here parses the SQL, so its case is the database's business."""
     mock_db_connection.fetch.return_value = []
     await writer.query("select * from states")
-    assert mock_db_connection.fetch.called
+    mock_db_connection.cursor.assert_called_once_with("select * from states")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Two ways `scribe.query` could hurt the machine it runs on:

- the timeout was **two minutes** — a long time to hold a pooled connection and work the server;
- **nothing bounded the answer**. `SELECT * FROM states` over a year is tens of millions of rows, loaded into Home Assistant's memory in full before anything could be done with them.

A query now has **60 seconds** and **10 000 rows**. Rows are streamed through a cursor and counted as they arrive, so a runaway query is stopped while it reads rather than held in memory and then rejected, and the refusal says what to do: narrow it, group it with `time_bucket()`, add a `LIMIT`.

## And what it cannot do, now tested

Writing was already refused — the query runs in a `READ ONLY` transaction — but nothing tested it, and "it is read-only" is exactly the kind of claim worth a test. Against a real PostgreSQL, each of `UPDATE`, `DELETE`, `TRUNCATE`, `DROP`, `INSERT`, `CREATE TABLE`, `ALTER`, `CREATE INDEX`, `GRANT` is refused with *cannot execute … in a read-only transaction*, and the database is checked to be untouched afterwards.

Two statements in one string (`SELECT 1; DELETE …`) never even reach the transaction: the query goes through the extended protocol, which takes one statement and no more.

## Note

The unit tests mocked `conn.fetch`, which the code no longer calls. They now assert what matters — that the SQL reaches the database as written — and the shared mock grew a cursor.

446 tests pass, coverage 94 %.