### PR TITLE
docs: finish the front page, and document the summary views

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,64 +1,54 @@
-[🇬🇧 English](README.md) · [🇫🇷 Français](README.fr.md) · [🇪🇸 Español](README.es.md) · **🇩🇪 Deutsch**
+<div align="center">
 
-# Scribe — Hochleistungs-TimescaleDB-Integration für Home Assistant
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="brands_assets/dark_logo.png">
+  <img src="brands_assets/logo.png" alt="Scribe" width="300">
+</picture>
 
-Scribe ist eine Komponente der neuen Generation, die Zustände und Ereignisse von Home Assistant in eine TimescaleDB-Datenbank schreibt.
+### Home-Assistant-Historie in TimescaleDB
 
-**Warum Scribe?**
-Scribe ist anders gebaut. Anders als Integrationen, die auf synchrone Treiber oder den Standard-Recorder setzen, verwendet Scribe **`asyncpg`**, einen schnellen asynchronen PostgreSQL-Treiber. Dadurch bewältigt es sehr große Datenmengen, ohne die Event-Loop von Home Assistant zu blockieren. Ausgelegt ist es auf Stabilität, Geschwindigkeit und Effizienz.
+Jeder Zustand und jedes Ereignis, über `asyncpg` — ohne die Event-Loop zu blockieren.
 
-**Datenstruktur und Abfragen**
+[![Release](https://img.shields.io/github/v/release/jonathan-gtd/scribe?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases/latest) [![Downloads](https://img.shields.io/github/downloads/jonathan-gtd/scribe/total?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases) [![Tests](https://img.shields.io/github/actions/workflow/status/jonathan-gtd/scribe/tests.yaml?branch=master&label=tests)](https://github.com/jonathan-gtd/scribe/actions/workflows/tests.yaml) [![License](https://img.shields.io/github/license/jonathan-gtd/scribe?color=lightgrey)](LICENSE)
 
-Eine Erklärung der Datenstruktur und wie man sie abfragt, findest du hier: [Datenstruktur](docs/data-structure.md)
+[![lang en](https://img.shields.io/badge/lang-en-lightgrey)](README.md) [![lang fr](https://img.shields.io/badge/lang-fr-lightgrey)](README.fr.md) [![lang es](https://img.shields.io/badge/lang-es-lightgrey)](README.es.md) [![lang de](https://img.shields.io/badge/lang-de-41BDF5)](README.de.md)
 
-## Inhaltsverzeichnis
+</div>
 
-- [Funktionen](#funktionen)
-- [Installation](#installation)
-- [Konfiguration](#konfiguration)
-- [Speicher-Feinabstimmung](#speicher-feinabstimmung)
-- [Aufbewahrung](#aufbewahrung)
-- [Zusammenfassungen](#zusammenfassungen)
-- [Datenbankschema](#datenbankschema)
-- [Migration](#migration)
-- [Statistik-Sensoren](#statistik-sensoren)
-- [Dienste](#dienste)
-- [Dashboard / Ansicht](#dashboard--ansicht)
-- [Ökosystem / Verwandte Projekte](#ökosystem--verwandte-projekte)
-- [Fehlerbehebung](#fehlerbehebung)
-- [Lizenz](#lizenz)
+---
 
-## Funktionen
+Der Recorder von Home Assistant hält einige Wochen Historie in SQLite und wird langsamer, je größer sie wird. Scribe schreibt dieselben Zustände und Ereignisse nach **TimescaleDB**, wo Jahre schnell bleiben und einen Bruchteil des Platzes brauchen.
 
-- 🚀 **Konsequent asynchrone Architektur**: auf `asyncpg` aufgebaut, für nicht blockierende Schreibvorgänge mit hohem Durchsatz.
-- 📦 **TimescaleDB von Haus aus**: verwaltet Hypertables und Komprimierungsrichtlinien automatisch.
-- 📊 **Detaillierte Statistiken**: optionale Sensoren für Chunk-Anzahl, Komprimierungsraten (bis zu 97 % Ersparnis!) und Schreibleistung.
-- 🔒 **Sicher**: vollständige SSL/TLS-Unterstützung.
-- 📈 **Zustände und Ereignisse**: schreibt alle Zustandsänderungen und Ereignisse in die Tabellen `states` und `events`.
-- 👥 **Benutzerkontext**: synchronisiert die Home-Assistant-Benutzer automatisch in die Datenbank.
-- 🧩 **Entitäts-Metadaten**: synchronisiert die Entitäts-Registry (Namen, Plattformen usw.) automatisch in die Tabelle `entities`.
-- 🏠 **Bereiche und Geräte**: synchronisiert Bereiche und Geräte automatisch in die Tabellen `areas` und `devices`.
-- 🔌 **Integrationsinfos**: synchronisiert die Konfigurationseinträge der Integrationen automatisch in die Tabelle `integrations`.
-- 🎯 **Feines Filtern**: Ein- und Ausschluss nach Domain, Entität, Entitätsmuster oder Attribut.
-- ✅ **Gegen eine echte Datenbank getestet**: rund 90 % Zeilenabdeckung, dazu eine End-to-End-Suite, die die Integration gegen eine echte TimescaleDB fährt statt gegen Mocks.
+- 🚀 **Durchgehend asynchron** — `asyncpg` und gebündelte `COPY`: die Aufzeichnung blockiert Home Assistant nie.
+- 🗜️ **Automatisch komprimiert** — alte Historie wird in Chunks geteilt und komprimiert, typischerweise 10× kleiner.
+- 🛟 **Nichts geht verloren** — eine nicht erreichbare Datenbank wird gepuffert und geschrieben, sobald sie zurück ist.
+- 🧩 **Mit Kontext** — Entitäten, Geräte, Bereiche, Benutzer und Integrationen, nicht nur Werte.
+- 🩺 **Es sagt, wenn etwas nicht stimmt**, in Reparaturen statt in einem Log, das niemand liest.
 
 ## Installation
 
-### 1. Komponente installieren
+**1. Eine TimescaleDB-Datenbank.** Die Erweiterung ist erforderlich — siehe *TimescaleDB einrichten* weiter unten.
 
-**HACS (empfohlen)**
+**2. Scribe, über HACS:**
 
-[![Öffne deine Home-Assistant-Instanz und ein Repository im Home Assistant Community Store.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jonathan-gtd&repository=scribe&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jonathan-gtd&repository=scribe&category=integration)
 
-1. Füge dieses Repository in HACS als benutzerdefiniertes Repository hinzu.
-2. Suche nach „Scribe“ und installiere es.
-3. Starte Home Assistant neu.
+*Oder von Hand:* `custom_components/scribe` in Ihren `custom_components`-Ordner kopieren. In beiden Fällen Home Assistant neu starten.
 
-**Manuell**
-1. Kopiere den Ordner `custom_components/scribe` in das Verzeichnis `custom_components` deiner Home-Assistant-Installation.
-2. Starte Home Assistant neu.
+**3. Die Datenbank-URL**, in `configuration.yaml`:
 
-### 2. Datenbank einrichten
+```yaml
+scribe:
+  db_url: "postgresql://scribe:password@192.168.1.10:5432/scribe"
+```
+
+Fertig — Zustände werden aufgezeichnet, in Chunks geteilt und komprimiert, mit ihrem Entitäts-, Geräte- und Bereichskontext. Alles Weitere ist optional.
+
+<details>
+<summary><b>🗄️ TimescaleDB einrichten</b></summary>
+<br>
+
+### Datenbank einrichten
 
 Du brauchst eine laufende TimescaleDB-Instanz. Ich empfehle PostgreSQL 17 oder 18.
 
@@ -100,19 +90,15 @@ CREATE EXTENSION IF NOT EXISTS timescaledb;
 GRANT ALL ON SCHEMA public TO scribe;
 ```
 
-## Konfiguration
+</details>
 
-### Minimale Konfiguration
-
-```yaml
-scribe:
-  db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
-```
+<details>
+<summary><b>⚙️ Alle Optionen, mit ihren Standardwerten</b></summary>
+<br>
 
 ### Vollständige Konfiguration (Standardwerte)
 
-<details>
-<summary><b>Vollständige YAML-Konfiguration anzeigen</b></summary>
+#### Vollständige YAML-Konfiguration anzeigen
 
 ```yaml
 scribe:
@@ -156,12 +142,14 @@ scribe:
   enable_table_users: true
   enable_rollups: false
 ```
+
 </details>
 
-### Konfigurationsparameter
-
 <details>
-<summary><b>Parameter-Referenz anzeigen</b></summary>
+<summary><b>📋 Parameter-Referenz</b></summary>
+<br>
+
+#### Parameter-Referenz anzeigen
 
 | Parameter | Beschreibung |
 | :--- | :--- |
@@ -203,9 +191,12 @@ scribe:
 | `enable_table_integrations` | Anlegen und Synchronisieren der Tabelle `integrations` aktivieren. |
 | `enable_table_users` | Anlegen und Synchronisieren der Tabelle `users` aktivieren. |
 | `enable_rollups` | Vorberechnete stündliche und tägliche Zusammenfassungen der Zustände vorhalten (`states_hourly`, `states_daily`). Standardmäßig aus. |
+
 </details>
 
-## Speicher-Feinabstimmung
+<details>
+<summary><b>🗜️ Speicher-Feinabstimmung — Chunks und Kompression</b></summary>
+<br>
 
 Scribe legt den Verlauf in **Hypertables** von TimescaleDB ab: eine Tabelle, die
 sich wie jede andere verhält und abfragen lässt, physisch aber in **Chunks**
@@ -281,7 +272,11 @@ Sind die Größen- und Chunk-Sensoren aktiviert (`enable_stats_size`,
 Chunk-Anzahl, komprimierte und unkomprimierte Größen sowie die
 Komprimierungsrate.
 
-## Aufbewahrung
+</details>
+
+<details>
+<summary><b>🧹 Aufbewahrung — alte Historie planmäßig löschen</b></summary>
+<br>
 
 Standardmäßig behält Scribe alles, unbegrenzt. Wenn du nur ein begrenztes
 Zeitfenster speichern willst — weil du den Rohverlauf anderswo aggregierst oder
@@ -334,7 +329,11 @@ Wissenswertes:
   andere wird mit einem Fehler abgelehnt, statt an die Datenbank geschickt zu
   werden.
 
-## Zusammenfassungen
+</details>
+
+<details>
+<summary><b>📈 Zusammenfassungen — stündliche und tägliche Aggregate</b></summary>
+<br>
 
 Ein Jahr eines Sensors, der alle 30 Sekunden meldet, sind rund eine Million Zeilen. Ein Diagramm dieses Jahres liest sie alle — jedes Mal, wenn es gezeichnet wird.
 
@@ -364,7 +363,11 @@ Zusammengefasst werden nur numerische Zustände — der Mittelwert von `on` und 
 
 **Es sind abgeleitete Daten.** Nichts, was Sie vermissen würden, wird doppelt gehalten: Ausschalten löscht beide Sichten, Wiedereinschalten baut sie aus der Historie neu auf, und Ihre Zustände bleiben in beiden Fällen unberührt. TimescaleDB hält sie selbst aktuell; Scribe legt sie nur an.
 
-## Datenbankschema
+</details>
+
+<details>
+<summary><b>🗃️ Datenbankschema — Tabellen, Sichten und wie man sie abfragt</b></summary>
+<br>
 
 Standardmäßig schreibt Scribe in das Schema, auf das die Verbindung ohnehin
 zeigt — normalerweise `public`. Wird `db_schema` gesetzt, legt Scribe dieses
@@ -420,173 +423,11 @@ Wissenswertes:
   nutzen — auch eines, das Sie selbst mit `?options=-csearch_path%3Dmeinschema`
   in der URL gesetzt haben; Scribe folgt ihm und überschreibt es nicht.
 
-## Migration
-
-### Aktualisierung von Scribe 2.x
-
-Scribe 3.0 ersetzte die Tabelle `states` durch `states_raw` plus eine
-Kompatibilitäts-Sicht und gab `entities` einen numerischen Primärschlüssel. Die
-Umwandlung einer alten Datenbank trugen die 3.x-Versionen; **in 3.9 wurde sie
-entfernt**.
-
-Wenn deine Datenbank noch eine `states`-*Tabelle* (statt einer Sicht), eine
-Tabelle `states_legacy` oder eine Tabelle `entities` ohne Spalte `id` enthält,
-hält Scribe beim Start an, zeichnet nichts auf und meldet einen Eintrag unter
-Reparaturen — ohne irgendetwas umzubenennen, anzulegen oder zu löschen.
-Installiere **Scribe 3.8**, lass Home Assistant laufen, bis das Protokoll die
-abgeschlossene Migration meldet (bei einer großen Datenbank rund fünfzehn
-Minuten), und aktualisiere dann erneut.
-
-Neuinstallationen und jede von 3.x angelegte Datenbank sind nicht betroffen.
-
-### Daten aus anderen Quellen übernehmen
-
-Scribe bringt Skripte mit, um Daten aus verschiedenen Quellen zu übernehmen.
-
-### Migration aus InfluxDB
-
-<details>
-<summary><b>InfluxDB-Migrationsanleitung anzeigen</b></summary>
-
-1. Wechsle in das Verzeichnis `migration`:
-   ```bash
-   cd migration
-   ```
-
-2. Installiere die Abhängigkeiten:
-   ```bash
-   pip install influxdb-client psycopg2-binary python-dotenv
-   ```
-
-3. Konfiguriere die Migration:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Trage [InfluxDB Configuration], [Scribe Configuration] und [Migration Settings] ein
-   ```
-
-4. Starte die Migration:
-   ```bash
-   python3 influx2scribe.py
-   ```
 </details>
 
-### Migration aus LTSS
-
 <details>
-<summary><b>LTSS-Migrationsanleitung anzeigen</b></summary>
-
-1. Wechsle in das Verzeichnis `migration`:
-   ```bash
-   cd migration
-   ```
-
-2. Installiere die Abhängigkeiten:
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Konfiguriere die Migration:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Trage [LTSS Configuration], [Scribe Configuration] und [Migration Settings] ein
-   ```
-
-4. Starte die Migration:
-   ```bash
-   python3 ltss2scribe.py
-   ```
-</details>
-
-### Migration aus dem Recorder
-
-<details>
-<summary><b>Recorder-Migrationsanleitung anzeigen</b></summary>
-
-1. Wechsle in das Verzeichnis `migration`:
-   ```bash
-   cd migration
-   ```
-
-2. Installiere die Abhängigkeiten:
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Konfiguriere die Migration:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Trage [Recorder Configuration], [Scribe Configuration] und [Migration Settings] ein
-   ```
-
-4. Starte die Migration:
-   ```bash
-   python3 recorder2scribe.py
-   ```
-</details>
-
-## Statistik-Sensoren
-
-Aktiviere die Sensoren, indem du ihre Optionen in der Konfiguration setzt.
-
-### Schreibstatistiken (`enable_stats_io: true`)
-
-<details>
-<summary><b>Schreib-Sensoren anzeigen</b></summary>
-
-Echtzeitwerte aus dem Writer (ohne Datenbankabfragen).
-
-| Sensor | Beschreibung |
-| :--- | :--- |
-| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_states_written` | Gesamtzahl der in die Datenbank geschriebenen Zustandsänderungen. |
-| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_events_written` | Gesamtzahl der in die Datenbank geschriebenen Ereignisse. |
-| <img src="https://api.iconify.design/mdi:buffer.svg?color=%232196F3" width="15" /> `sensor.scribe_buffer_size` | Aktuelle Anzahl der Einträge im Speicherpuffer. |
-| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_write_duration` | Dauer (in ms) des letzten Schreibvorgangs. |
-| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_states_rate` | Rate der geschriebenen Zustände (pro Minute). |
-| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_events_rate` | Rate der geschriebenen Ereignisse (pro Minute). |
-</details>
-
-### Chunk-Statistiken (`enable_stats_chunk: true`)
-
-<details>
-<summary><b>Chunk-Sensoren anzeigen</b></summary>
-
-Chunk-Anzahl (alle `stats_chunk_interval` Minuten aktualisiert).
-
-| Sensor | Beschreibung |
-| :--- | :--- |
-| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_chunks` | Gesamtzahl der Chunks der Zustandstabelle. |
-| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_chunks` | Anzahl der bereits komprimierten Chunks. |
-| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_chunks` | Anzahl der Chunks, die auf Komprimierung warten. |
-| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_chunks` | Gesamtzahl der Chunks der Ereignistabelle. |
-| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_chunks` | Anzahl der komprimierten Ereignis-Chunks. |
-| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_chunks` | Anzahl der unkomprimierten Ereignis-Chunks. |
-</details>
-
-### Größenstatistiken (`enable_stats_size: true`)
-
-<details>
-<summary><b>Größen-Sensoren anzeigen</b></summary>
-
-Belegter Speicher in Bytes (alle `stats_size_interval` Minuten aktualisiert).
-
-| Sensor | Beschreibung |
-| :--- | :--- |
-| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_size` | Gesamtgröße auf der Platte (komprimierte Daten + aktuelle Chunks + Indizes). |
-| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_states_original_size` | **Theoretische Größe** ohne Komprimierung (z. B. 11 GB). |
-| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_size` | Physische Größe der komprimierten Daten-Chunks. |
-| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_size` | Größe der noch nicht komprimierten aktuellen Daten (oder ausstehender Indizes). |
-| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compression_ratio` | Komprimierungsrate der Zustände (%). |
-| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_size` | Gesamtgröße der Ereignistabelle auf der Platte. |
-| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_events_original_size` | Theoretische Größe der Ereignisse vor der Komprimierung. |
-| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_size` | Größe der komprimierten Ereignisdaten. |
-| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_size` | Größe der unkomprimierten Ereignisdaten. |
-| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compression_ratio` | Komprimierungsrate der Ereignisse (%). |
-</details>
-
-## Dienste
+<summary><b>🛠️ Dienste — flush, query, purge</b></summary>
+<br>
 
 ### `scribe.flush`
 Erzwingt das sofortige Schreiben der gepufferten Daten in die Datenbank.
@@ -641,7 +482,209 @@ response_variable: purged
 
 Komprimierte Historie wird ebenfalls gelöscht: TimescaleDB erledigt das, und die Chunks bleiben komprimiert. Für ein gleitendes Fenster, das dauerhaft gilt, nutzen Sie stattdessen die [Aufbewahrung](#aufbewahrung): eine Purge ist einmalig.
 
-## Fehlerbehebung
+</details>
+
+<details>
+<summary><b>📊 Statistik-Sensoren</b></summary>
+<br>
+
+Aktiviere die Sensoren, indem du ihre Optionen in der Konfiguration setzt.
+
+### Schreibstatistiken (`enable_stats_io: true`)
+
+#### Schreib-Sensoren anzeigen
+
+Echtzeitwerte aus dem Writer (ohne Datenbankabfragen).
+
+| Sensor | Beschreibung |
+| :--- | :--- |
+| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_states_written` | Gesamtzahl der in die Datenbank geschriebenen Zustandsänderungen. |
+| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_events_written` | Gesamtzahl der in die Datenbank geschriebenen Ereignisse. |
+| <img src="https://api.iconify.design/mdi:buffer.svg?color=%232196F3" width="15" /> `sensor.scribe_buffer_size` | Aktuelle Anzahl der Einträge im Speicherpuffer. |
+| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_write_duration` | Dauer (in ms) des letzten Schreibvorgangs. |
+| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_states_rate` | Rate der geschriebenen Zustände (pro Minute). |
+| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_events_rate` | Rate der geschriebenen Ereignisse (pro Minute). |
+
+
+### Chunk-Statistiken (`enable_stats_chunk: true`)
+
+#### Chunk-Sensoren anzeigen
+
+Chunk-Anzahl (alle `stats_chunk_interval` Minuten aktualisiert).
+
+| Sensor | Beschreibung |
+| :--- | :--- |
+| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_chunks` | Gesamtzahl der Chunks der Zustandstabelle. |
+| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_chunks` | Anzahl der bereits komprimierten Chunks. |
+| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_chunks` | Anzahl der Chunks, die auf Komprimierung warten. |
+| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_chunks` | Gesamtzahl der Chunks der Ereignistabelle. |
+| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_chunks` | Anzahl der komprimierten Ereignis-Chunks. |
+| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_chunks` | Anzahl der unkomprimierten Ereignis-Chunks. |
+
+
+### Größenstatistiken (`enable_stats_size: true`)
+
+#### Größen-Sensoren anzeigen
+
+Belegter Speicher in Bytes (alle `stats_size_interval` Minuten aktualisiert).
+
+| Sensor | Beschreibung |
+| :--- | :--- |
+| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_size` | Gesamtgröße auf der Platte (komprimierte Daten + aktuelle Chunks + Indizes). |
+| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_states_original_size` | **Theoretische Größe** ohne Komprimierung (z. B. 11 GB). |
+| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_size` | Physische Größe der komprimierten Daten-Chunks. |
+| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_size` | Größe der noch nicht komprimierten aktuellen Daten (oder ausstehender Indizes). |
+| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compression_ratio` | Komprimierungsrate der Zustände (%). |
+| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_size` | Gesamtgröße der Ereignistabelle auf der Platte. |
+| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_events_original_size` | Theoretische Größe der Ereignisse vor der Komprimierung. |
+| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_size` | Größe der komprimierten Ereignisdaten. |
+| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_size` | Größe der unkomprimierten Ereignisdaten. |
+| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compression_ratio` | Komprimierungsrate der Ereignisse (%). |
+
+</details>
+
+<details>
+<summary><b>🖼️ Dashboard</b></summary>
+<br>
+
+Ein vorbereitetes Lovelace-Layout mit allen nützlichen Scribe-Sensoren
+(Datenbankstatistiken, Komprimierungsraten, Schreibleistung) liegt in diesem
+Repository, in zwei Varianten:
+
+| Datei | Was es ist | Wohin einfügen |
+| --- | --- | --- |
+| [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml) | Eine **einzelne Karte** (`type: vertical-stack`) | Der YAML-Editor einer Karte („Karte hinzufügen“ → „Manuell“) |
+| [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml) | Eine **ganze Ansicht** (`title` / `icon` / `cards`) | Der YAML-Editor einer Ansicht |
+
+> ⚠️ Die beiden sind nicht austauschbar. Die *Ansicht*-Datei in einen
+> *Karten*-Editor einzufügen scheitert mit **„No card type configured“**, denn
+> eine Kartenkonfiguration muss mit einem `type:`-Schlüssel beginnen.
+
+**Variante A — als Karte hinzufügen (am einfachsten, funktioniert in jedem Ansichtstyp):**
+
+1.  Öffne dein Dashboard und klicke auf „Dashboard bearbeiten“ (Stiftsymbol).
+2.  Klicke auf **+ Karte hinzufügen** und wähle ganz unten in der Auswahl **Manuell**.
+3.  Kopiere den Inhalt von [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml), ersetze damit alles im Editor und klicke auf **Speichern**.
+
+**Variante B — als eigene Ansicht hinzufügen:**
+
+1.  Öffne dein Dashboard und klicke auf „Dashboard bearbeiten“ (Stiftsymbol).
+2.  Klicke auf die Schaltfläche **+** *in der oberen Reiterleiste* (neben deinen vorhandenen Ansichten), um eine Ansicht hinzuzufügen — nicht auf „Karte hinzufügen“.
+3.  Öffne im Ansichtsdialog das Menü ⋮ (oder die Schaltfläche „Code-Editor anzeigen“) und wähle **In YAML bearbeiten**.
+4.  Kopiere den Inhalt von [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml), ersetze damit alles im Editor und klicke auf **Speichern**.
+
+</details>
+
+<details>
+<summary><b>📦 Migration von InfluxDB, LTSS, dem Recorder oder Scribe 2.x</b></summary>
+<br>
+
+### Aktualisierung von Scribe 2.x
+
+Scribe 3.0 ersetzte die Tabelle `states` durch `states_raw` plus eine
+Kompatibilitäts-Sicht und gab `entities` einen numerischen Primärschlüssel. Die
+Umwandlung einer alten Datenbank trugen die 3.x-Versionen; **in 3.9 wurde sie
+entfernt**.
+
+Wenn deine Datenbank noch eine `states`-*Tabelle* (statt einer Sicht), eine
+Tabelle `states_legacy` oder eine Tabelle `entities` ohne Spalte `id` enthält,
+hält Scribe beim Start an, zeichnet nichts auf und meldet einen Eintrag unter
+Reparaturen — ohne irgendetwas umzubenennen, anzulegen oder zu löschen.
+Installiere **Scribe 3.8**, lass Home Assistant laufen, bis das Protokoll die
+abgeschlossene Migration meldet (bei einer großen Datenbank rund fünfzehn
+Minuten), und aktualisiere dann erneut.
+
+Neuinstallationen und jede von 3.x angelegte Datenbank sind nicht betroffen.
+
+### Daten aus anderen Quellen übernehmen
+
+Scribe bringt Skripte mit, um Daten aus verschiedenen Quellen zu übernehmen.
+
+### Migration aus InfluxDB
+
+#### InfluxDB-Migrationsanleitung anzeigen
+
+1. Wechsle in das Verzeichnis `migration`:
+   ```bash
+   cd migration
+   ```
+
+2. Installiere die Abhängigkeiten:
+   ```bash
+   pip install influxdb-client psycopg2-binary python-dotenv
+   ```
+
+3. Konfiguriere die Migration:
+   ```bash
+   cp .env.example .env
+   nano .env
+   # Trage [InfluxDB Configuration], [Scribe Configuration] und [Migration Settings] ein
+   ```
+
+4. Starte die Migration:
+   ```bash
+   python3 influx2scribe.py
+   ```
+
+
+### Migration aus LTSS
+
+#### LTSS-Migrationsanleitung anzeigen
+
+1. Wechsle in das Verzeichnis `migration`:
+   ```bash
+   cd migration
+   ```
+
+2. Installiere die Abhängigkeiten:
+   ```bash
+   pip install psycopg2-binary python-dotenv
+   ```
+
+3. Konfiguriere die Migration:
+   ```bash
+   cp .env.example .env
+   nano .env
+   # Trage [LTSS Configuration], [Scribe Configuration] und [Migration Settings] ein
+   ```
+
+4. Starte die Migration:
+   ```bash
+   python3 ltss2scribe.py
+   ```
+
+
+### Migration aus dem Recorder
+
+#### Recorder-Migrationsanleitung anzeigen
+
+1. Wechsle in das Verzeichnis `migration`:
+   ```bash
+   cd migration
+   ```
+
+2. Installiere die Abhängigkeiten:
+   ```bash
+   pip install psycopg2-binary python-dotenv
+   ```
+
+3. Konfiguriere die Migration:
+   ```bash
+   cp .env.example .env
+   nano .env
+   # Trage [Recorder Configuration], [Scribe Configuration] und [Migration Settings] ein
+   ```
+
+4. Starte die Migration:
+   ```bash
+   python3 recorder2scribe.py
+   ```
+
+</details>
+
+<details>
+<summary><b>🩺 Fehlerbehebung</b></summary>
+<br>
 
 ### Was man zuerst ansieht
 
@@ -710,40 +753,18 @@ Loops), die für Scribes Leistung bei großen Datenmengen entscheidend sind.
 ### Immer noch Probleme?
 [Öffne bitte ein Issue](https://github.com/jonathan-gtd/scribe/issues) auf GitHub mit deinen Protokollen und deiner Konfiguration. Ich helfe gerne!
 
-## Dashboard / Ansicht
+</details>
 
-Ein vorbereitetes Lovelace-Layout mit allen nützlichen Scribe-Sensoren
-(Datenbankstatistiken, Komprimierungsraten, Schreibleistung) liegt in diesem
-Repository, in zwei Varianten:
-
-| Datei | Was es ist | Wohin einfügen |
-| --- | --- | --- |
-| [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml) | Eine **einzelne Karte** (`type: vertical-stack`) | Der YAML-Editor einer Karte („Karte hinzufügen“ → „Manuell“) |
-| [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml) | Eine **ganze Ansicht** (`title` / `icon` / `cards`) | Der YAML-Editor einer Ansicht |
-
-> ⚠️ Die beiden sind nicht austauschbar. Die *Ansicht*-Datei in einen
-> *Karten*-Editor einzufügen scheitert mit **„No card type configured“**, denn
-> eine Kartenkonfiguration muss mit einem `type:`-Schlüssel beginnen.
-
-**Variante A — als Karte hinzufügen (am einfachsten, funktioniert in jedem Ansichtstyp):**
-
-1.  Öffne dein Dashboard und klicke auf „Dashboard bearbeiten“ (Stiftsymbol).
-2.  Klicke auf **+ Karte hinzufügen** und wähle ganz unten in der Auswahl **Manuell**.
-3.  Kopiere den Inhalt von [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml), ersetze damit alles im Editor und klicke auf **Speichern**.
-
-**Variante B — als eigene Ansicht hinzufügen:**
-
-1.  Öffne dein Dashboard und klicke auf „Dashboard bearbeiten“ (Stiftsymbol).
-2.  Klicke auf die Schaltfläche **+** *in der oberen Reiterleiste* (neben deinen vorhandenen Ansichten), um eine Ansicht hinzuzufügen — nicht auf „Karte hinzufügen“.
-3.  Öffne im Ansichtsdialog das Menü ⋮ (oder die Schaltfläche „Code-Editor anzeigen“) und wähle **In YAML bearbeiten**.
-4.  Kopiere den Inhalt von [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml), ersetze damit alles im Editor und klicke auf **Speichern**.
-
-## Ökosystem / Verwandte Projekte
+<details>
+<summary><b>🔗 Verwandte Projekte</b></summary>
+<br>
 
 Diese Projekte harmonieren gut mit Scribe:
 
 - [timescale_database_reader](https://github.com/remmob/timescale_database_reader): eine benutzerdefinierte Komponente, die Daten aus TimescaleDB zurück in Home-Assistant-Sensoren liest.
 - [timescale-plotly-card](https://github.com/remmob/timescale-plotly-card): eine hochgradig anpassbare Karte auf Plotly-Basis, die TimescaleDB direkt abfragen kann.
+
+</details>
 
 ## Lizenz
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,64 +1,54 @@
-[🇬🇧 English](README.md) · [🇫🇷 Français](README.fr.md) · **🇪🇸 Español** · [🇩🇪 Deutsch](README.de.md)
+<div align="center">
 
-# Scribe — Integración TimescaleDB de alto rendimiento para Home Assistant
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="brands_assets/dark_logo.png">
+  <img src="brands_assets/logo.png" alt="Scribe" width="300">
+</picture>
 
-Scribe es un componente de nueva generación que escribe los estados y eventos de Home Assistant en una base de datos TimescaleDB.
+### El historial de Home Assistant en TimescaleDB
 
-**¿Por qué Scribe?**
-Scribe está construido de otra manera. A diferencia de las integraciones que dependen de controladores síncronos o del recorder por defecto, Scribe usa **`asyncpg`**, un controlador PostgreSQL asíncrono de alto rendimiento. Esto le permite gestionar volúmenes enormes de datos sin bloquear el bucle de eventos de Home Assistant. Está diseñado para la estabilidad, la velocidad y la eficiencia.
+Cada estado y cada evento, mediante `asyncpg` — sin bloquear el bucle de eventos.
 
-**Estructura de datos y consultas**
+[![Release](https://img.shields.io/github/v/release/jonathan-gtd/scribe?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases/latest) [![Downloads](https://img.shields.io/github/downloads/jonathan-gtd/scribe/total?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases) [![Tests](https://img.shields.io/github/actions/workflow/status/jonathan-gtd/scribe/tests.yaml?branch=master&label=tests)](https://github.com/jonathan-gtd/scribe/actions/workflows/tests.yaml) [![License](https://img.shields.io/github/license/jonathan-gtd/scribe?color=lightgrey)](LICENSE)
 
-Aquí encontrarás una explicación de la estructura de datos y de cómo consultarla: [Estructura de datos](docs/data-structure.md)
+[![lang en](https://img.shields.io/badge/lang-en-lightgrey)](README.md) [![lang fr](https://img.shields.io/badge/lang-fr-lightgrey)](README.fr.md) [![lang es](https://img.shields.io/badge/lang-es-41BDF5)](README.es.md) [![lang de](https://img.shields.io/badge/lang-de-lightgrey)](README.de.md)
 
-## Índice
+</div>
 
-- [Características](#características)
-- [Instalación](#instalación)
-- [Configuración](#configuración)
-- [Ajuste del almacenamiento](#ajuste-del-almacenamiento)
-- [Retención](#retención)
-- [Resúmenes](#resúmenes)
-- [Esquema de la base de datos](#esquema-de-la-base-de-datos)
-- [Migración](#migración)
-- [Sensores de estadísticas](#sensores-de-estadísticas)
-- [Servicios](#servicios)
-- [Panel / Vista](#panel--vista)
-- [Ecosistema / Proyectos relacionados](#ecosistema--proyectos-relacionados)
-- [Solución de problemas](#solución-de-problemas)
-- [Licencia](#licencia)
+---
 
-## Características
+El recorder de Home Assistant guarda unas semanas de historial en SQLite y se ralentiza a medida que crece. Scribe escribe los mismos estados y eventos en **TimescaleDB**, donde los años siguen siendo rápidos y ocupan una fracción del espacio.
 
-- 🚀 **Arquitectura asíncrona ante todo**: construida sobre `asyncpg` para escrituras no bloqueantes y de alto rendimiento.
-- 📦 **TimescaleDB nativo**: gestiona automáticamente las hypertables y las políticas de compresión.
-- 📊 **Estadísticas detalladas**: sensores opcionales para vigilar el número de chunks, los ratios de compresión (¡hasta un 97 % de ahorro!) y el rendimiento de escritura.
-- 🔒 **Seguro**: compatibilidad completa con SSL/TLS.
-- 📈 **Estados y eventos**: registra todos los cambios de estado y los eventos en las tablas `states` y `events`.
-- 👥 **Contexto de usuario**: sincroniza automáticamente los usuarios de Home Assistant en la base de datos para dar más contexto.
-- 🧩 **Metadatos de entidades**: sincroniza automáticamente el registro de entidades (nombres, plataformas, etc.) en la tabla `entities`.
-- 🏠 **Contexto de áreas y dispositivos**: sincroniza automáticamente áreas y dispositivos en las tablas `areas` y `devices`.
-- 🔌 **Información de integraciones**: sincroniza automáticamente las entradas de configuración en la tabla `integrations`.
-- 🎯 **Filtrado preciso**: incluir o excluir por dominio, entidad, patrón de entidad o atributo.
-- ✅ **Probado contra una base de datos real**: ~90 % de cobertura de líneas, y una suite de extremo a extremo que ejecuta la integración contra una TimescaleDB real en lugar de mocks.
+- 🚀 **Asíncrono de extremo a extremo** — `asyncpg` y `COPY` por lotes: el registro nunca bloquea Home Assistant.
+- 🗜️ **Comprimido automáticamente** — el historial antiguo se divide en chunks y se comprime, normalmente 10× más pequeño.
+- 🛟 **Nada se pierde** — una base de datos caída se almacena en búfer y se escribe cuando vuelve.
+- 🧩 **Con su contexto** — entidades, dispositivos, áreas, usuarios e integraciones, no solo valores.
+- 🩺 **Avisa cuando algo va mal**, en Reparaciones en lugar de en un registro que nadie lee.
 
 ## Instalación
 
-### 1. Instalar el componente
+**1. Una base de datos TimescaleDB.** La extensión es obligatoria — vea *Instalar TimescaleDB* más abajo.
 
-**HACS (recomendado)**
+**2. Scribe, mediante HACS:**
 
-[![Abre tu instancia de Home Assistant y abre un repositorio en la Home Assistant Community Store.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jonathan-gtd&repository=scribe&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jonathan-gtd&repository=scribe&category=integration)
 
-1. Añade este repositorio como repositorio personalizado en HACS.
-2. Busca «Scribe» e instálalo.
-3. Reinicia Home Assistant.
+*O a mano:* copie `custom_components/scribe` en su carpeta `custom_components`. En ambos casos, reinicie Home Assistant.
 
-**Manual**
-1. Copia la carpeta `custom_components/scribe` en el directorio `custom_components` de tu Home Assistant.
-2. Reinicia Home Assistant.
+**3. La URL de la base de datos**, en `configuration.yaml`:
 
-### 2. Preparar la base de datos
+```yaml
+scribe:
+  db_url: "postgresql://scribe:password@192.168.1.10:5432/scribe"
+```
+
+Listo — los estados se registran, se dividen en chunks y se comprimen, con su contexto de entidad, dispositivo y área. Todo lo que sigue es opcional.
+
+<details>
+<summary><b>🗄️ Instalar TimescaleDB</b></summary>
+<br>
+
+### Preparar la base de datos
 
 Necesitas una instancia de TimescaleDB en funcionamiento. Recomiendo PostgreSQL 17 o 18.
 
@@ -100,19 +90,15 @@ CREATE EXTENSION IF NOT EXISTS timescaledb;
 GRANT ALL ON SCHEMA public TO scribe;
 ```
 
-## Configuración
+</details>
 
-### Configuración mínima
-
-```yaml
-scribe:
-  db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
-```
+<details>
+<summary><b>⚙️ Todas las opciones, con sus valores por defecto</b></summary>
+<br>
 
 ### Configuración completa (valores por defecto)
 
-<details>
-<summary><b>Mostrar la configuración YAML completa</b></summary>
+#### Mostrar la configuración YAML completa
 
 ```yaml
 scribe:
@@ -156,12 +142,14 @@ scribe:
   enable_table_users: true
   enable_rollups: false
 ```
+
 </details>
 
-### Parámetros de configuración
-
 <details>
-<summary><b>Mostrar la referencia de parámetros</b></summary>
+<summary><b>📋 Referencia de parámetros</b></summary>
+<br>
+
+#### Mostrar la referencia de parámetros
 
 | Parámetro | Descripción |
 | :--- | :--- |
@@ -203,9 +191,12 @@ scribe:
 | `enable_table_integrations` | Activar la creación y sincronización de la tabla `integrations`. |
 | `enable_table_users` | Activar la creación y sincronización de la tabla `users`. |
 | `enable_rollups` | Mantener resúmenes por hora y por día precalculados de los estados (`states_hourly`, `states_daily`). Desactivado por defecto. |
+
 </details>
 
-## Ajuste del almacenamiento
+<details>
+<summary><b>🗜️ Ajuste del almacenamiento — chunks y compresión</b></summary>
+<br>
 
 Scribe guarda el historial en **hypertables** de TimescaleDB: una tabla que se
 usa y se consulta como cualquier otra, pero que está físicamente dividida en
@@ -278,7 +269,11 @@ Si los sensores de tamaño y de chunks están activados (`enable_stats_size`,
 `enable_stats_chunk`), informan exactamente de lo que producen estos ajustes:
 número de chunks, tamaños comprimido y sin comprimir, y ratio de compresión.
 
-## Retención
+</details>
+
+<details>
+<summary><b>🧹 Retención — eliminar el historial antiguo automáticamente</b></summary>
+<br>
 
 Por defecto, Scribe lo conserva todo, para siempre. Si solo quieres almacenar
 una ventana acotada —porque agregas el historial en bruto en otro sitio, o
@@ -330,7 +325,11 @@ Conviene saber:
   `1 year`. Cualquier otra cosa se rechaza con un error en vez de enviarse a la
   base de datos.
 
-## Resúmenes
+</details>
+
+<details>
+<summary><b>📈 Resúmenes — agregados por hora y por día</b></summary>
+<br>
 
 Un año de un sensor que informa cada 30 segundos son cerca de un millón de filas. Un gráfico de ese año las lee todas, cada vez que se dibuja.
 
@@ -360,7 +359,11 @@ Solo se resumen los estados numéricos —la media de `on` y `off` no significa 
 
 **Son datos derivados.** No se duplica nada que vaya a echar de menos: desactivar la opción elimina ambas vistas, reactivarla las reconstruye a partir del historial, y sus estados no se tocan en ningún caso. TimescaleDB las mantiene por sí mismo; Scribe solo las crea.
 
-## Esquema de la base de datos
+</details>
+
+<details>
+<summary><b>🗃️ Esquema de la base — tablas, vistas y cómo consultarlas</b></summary>
+<br>
 
 De forma predeterminada, Scribe registra en el esquema al que ya apunta su
 conexión — normalmente `public`. Indique `db_schema` y creará ese esquema y
@@ -413,172 +416,11 @@ Conviene saber:
   `?options=-csearch_path%3Dmiesquema` en la URL, que Scribe respeta y no
   sustituye.
 
-## Migración
-
-### Actualizar desde Scribe 2.x
-
-Scribe 3.0 sustituyó la tabla `states` por `states_raw` más una vista de
-compatibilidad, y dio a `entities` una clave primaria numérica. La conversión de
-una base antigua la hacían las versiones 3.x y se **eliminó en la 3.9**.
-
-Si tu base de datos todavía tiene una *tabla* `states` (en lugar de una vista),
-una tabla `states_legacy`, o una tabla `entities` sin columna `id`, Scribe se
-detiene al arrancar, no registra nada y genera un problema en Reparaciones, sin
-renombrar, crear ni eliminar nada. Instala **Scribe 3.8**, deja Home Assistant
-en marcha hasta que los registros indiquen que la migración ha terminado (unos
-quince minutos en una base grande) y actualiza de nuevo.
-
-Las instalaciones nuevas y cualquier base creada por una versión 3.x no se ven
-afectadas.
-
-### Importar datos desde otras fuentes
-
-Scribe incluye scripts para importar datos desde varias fuentes.
-
-### Migración desde InfluxDB
-
-<details>
-<summary><b>Mostrar la guía de migración de InfluxDB</b></summary>
-
-1. Sitúate en el directorio `migration`:
-   ```bash
-   cd migration
-   ```
-
-2. Instala las dependencias:
-   ```bash
-   pip install influxdb-client psycopg2-binary python-dotenv
-   ```
-
-3. Configura la migración:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Rellena [InfluxDB Configuration], [Scribe Configuration] y [Migration Settings]
-   ```
-
-4. Ejecuta la migración:
-   ```bash
-   python3 influx2scribe.py
-   ```
 </details>
 
-### Migración desde LTSS
-
 <details>
-<summary><b>Mostrar la guía de migración de LTSS</b></summary>
-
-1. Sitúate en el directorio `migration`:
-   ```bash
-   cd migration
-   ```
-
-2. Instala las dependencias:
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Configura la migración:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Rellena [LTSS Configuration], [Scribe Configuration] y [Migration Settings]
-   ```
-
-4. Ejecuta la migración:
-   ```bash
-   python3 ltss2scribe.py
-   ```
-</details>
-
-### Migración desde Recorder
-
-<details>
-<summary><b>Mostrar la guía de migración de Recorder</b></summary>
-
-1. Sitúate en el directorio `migration`:
-   ```bash
-   cd migration
-   ```
-
-2. Instala las dependencias:
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Configura la migración:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Rellena [Recorder Configuration], [Scribe Configuration] y [Migration Settings]
-   ```
-
-4. Ejecuta la migración:
-   ```bash
-   python3 recorder2scribe.py
-   ```
-</details>
-
-## Sensores de estadísticas
-
-Activa los sensores estableciendo sus opciones en la configuración.
-
-### Estadísticas de escritura (`enable_stats_io: true`)
-
-<details>
-<summary><b>Mostrar los sensores de escritura</b></summary>
-
-Métricas en tiempo real del escritor (sin consultas a la base de datos).
-
-| Sensor | Descripción |
-| :--- | :--- |
-| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_states_written` | Número total de cambios de estado escritos en la base. |
-| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_events_written` | Número total de eventos escritos en la base. |
-| <img src="https://api.iconify.design/mdi:buffer.svg?color=%232196F3" width="15" /> `sensor.scribe_buffer_size` | Elementos que esperan actualmente en el búfer de memoria. |
-| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_write_duration` | Tiempo (en ms) de la última escritura en la base. |
-| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_states_rate` | Ritmo de estados escritos (por minuto). |
-| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_events_rate` | Ritmo de eventos escritos (por minuto). |
-</details>
-
-### Estadísticas de chunks (`enable_stats_chunk: true`)
-
-<details>
-<summary><b>Mostrar los sensores de chunks</b></summary>
-
-Número de chunks (actualizado cada `stats_chunk_interval` minutos).
-
-| Sensor | Descripción |
-| :--- | :--- |
-| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_chunks` | Número total de chunks de la tabla de estados. |
-| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_chunks` | Número de chunks ya comprimidos. |
-| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_chunks` | Número de chunks pendientes de comprimir. |
-| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_chunks` | Número total de chunks de la tabla de eventos. |
-| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_chunks` | Número de chunks de eventos comprimidos. |
-| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_chunks` | Número de chunks de eventos sin comprimir. |
-</details>
-
-### Estadísticas de tamaño (`enable_stats_size: true`)
-
-<details>
-<summary><b>Mostrar los sensores de tamaño</b></summary>
-
-Espacio ocupado en bytes (actualizado cada `stats_size_interval` minutos).
-
-| Sensor | Descripción |
-| :--- | :--- |
-| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_size` | Tamaño total en disco (datos comprimidos + chunks recientes + índices). |
-| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_states_original_size` | **Tamaño teórico** si los datos no estuvieran comprimidos (p. ej. 11 GB). |
-| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_size` | Tamaño físico de los chunks de datos comprimidos. |
-| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_size` | Tamaño de los datos recientes aún sin comprimir (o índices pendientes). |
-| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compression_ratio` | Ratio de compresión de los estados (%). |
-| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_size` | Tamaño total en disco de la tabla de eventos. |
-| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_events_original_size` | Tamaño teórico de los eventos antes de comprimir. |
-| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_size` | Tamaño de los datos de eventos comprimidos. |
-| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_size` | Tamaño de los datos de eventos sin comprimir. |
-| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compression_ratio` | Ratio de compresión de los eventos (%). |
-</details>
-
-## Servicios
+<summary><b>🛠️ Servicios — flush, query, purge</b></summary>
+<br>
 
 ### `scribe.flush`
 Fuerza el volcado inmediato a la base de datos de los datos en búfer.
@@ -633,7 +475,208 @@ response_variable: purged
 
 El historial comprimido también se purga: TimescaleDB se encarga y los chunks siguen comprimidos. Para una ventana deslizante que se aplique continuamente, use los ajustes de [retención](#retención): una purga es puntual.
 
-## Solución de problemas
+</details>
+
+<details>
+<summary><b>📊 Sensores de estadísticas</b></summary>
+<br>
+
+Activa los sensores estableciendo sus opciones en la configuración.
+
+### Estadísticas de escritura (`enable_stats_io: true`)
+
+#### Mostrar los sensores de escritura
+
+Métricas en tiempo real del escritor (sin consultas a la base de datos).
+
+| Sensor | Descripción |
+| :--- | :--- |
+| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_states_written` | Número total de cambios de estado escritos en la base. |
+| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_events_written` | Número total de eventos escritos en la base. |
+| <img src="https://api.iconify.design/mdi:buffer.svg?color=%232196F3" width="15" /> `sensor.scribe_buffer_size` | Elementos que esperan actualmente en el búfer de memoria. |
+| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_write_duration` | Tiempo (en ms) de la última escritura en la base. |
+| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_states_rate` | Ritmo de estados escritos (por minuto). |
+| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_events_rate` | Ritmo de eventos escritos (por minuto). |
+
+
+### Estadísticas de chunks (`enable_stats_chunk: true`)
+
+#### Mostrar los sensores de chunks
+
+Número de chunks (actualizado cada `stats_chunk_interval` minutos).
+
+| Sensor | Descripción |
+| :--- | :--- |
+| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_chunks` | Número total de chunks de la tabla de estados. |
+| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_chunks` | Número de chunks ya comprimidos. |
+| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_chunks` | Número de chunks pendientes de comprimir. |
+| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_chunks` | Número total de chunks de la tabla de eventos. |
+| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_chunks` | Número de chunks de eventos comprimidos. |
+| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_chunks` | Número de chunks de eventos sin comprimir. |
+
+
+### Estadísticas de tamaño (`enable_stats_size: true`)
+
+#### Mostrar los sensores de tamaño
+
+Espacio ocupado en bytes (actualizado cada `stats_size_interval` minutos).
+
+| Sensor | Descripción |
+| :--- | :--- |
+| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_size` | Tamaño total en disco (datos comprimidos + chunks recientes + índices). |
+| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_states_original_size` | **Tamaño teórico** si los datos no estuvieran comprimidos (p. ej. 11 GB). |
+| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_size` | Tamaño físico de los chunks de datos comprimidos. |
+| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_size` | Tamaño de los datos recientes aún sin comprimir (o índices pendientes). |
+| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compression_ratio` | Ratio de compresión de los estados (%). |
+| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_size` | Tamaño total en disco de la tabla de eventos. |
+| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_events_original_size` | Tamaño teórico de los eventos antes de comprimir. |
+| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_size` | Tamaño de los datos de eventos comprimidos. |
+| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_size` | Tamaño de los datos de eventos sin comprimir. |
+| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compression_ratio` | Ratio de compresión de los eventos (%). |
+
+</details>
+
+<details>
+<summary><b>🖼️ Panel</b></summary>
+<br>
+
+En este repositorio hay una disposición Lovelace lista para usar con todos los
+sensores útiles de Scribe (estadísticas de la base, ratios de compresión,
+rendimiento de escritura), en dos variantes:
+
+| Archivo | Qué es | Dónde pegarlo |
+| --- | --- | --- |
+| [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml) | Una **sola tarjeta** (`type: vertical-stack`) | El editor YAML de tarjeta («Añadir tarjeta» → «Manual») |
+| [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml) | Una **vista completa** (`title` / `icon` / `cards`) | El editor YAML de vista |
+
+> ⚠️ No son intercambiables. Pegar el archivo de *vista* en un editor de
+> *tarjeta* falla con **«No card type configured»**, porque la configuración de
+> una tarjeta debe empezar por una clave `type:`.
+
+**Opción A — añadirla como tarjeta (lo más fácil, funciona en cualquier tipo de vista):**
+
+1.  Abre tu panel y pulsa «Editar panel» (icono del lápiz).
+2.  Pulsa **+ Añadir tarjeta** y baja hasta el final del selector para elegir **Manual**.
+3.  Copia el contenido de [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml), sustituye todo lo que haya en el editor y pulsa **Guardar**.
+
+**Opción B — añadirla como vista dedicada:**
+
+1.  Abre tu panel y pulsa «Editar panel» (icono del lápiz).
+2.  Pulsa el botón **+** *en la barra de pestañas superior* (junto a los nombres de tus vistas) para añadir una vista, no el botón «Añadir tarjeta».
+3.  En el diálogo de la vista, abre el menú ⋮ (o el botón «Mostrar editor de código») y elige **Editar en YAML**.
+4.  Copia el contenido de [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml), sustituye todo lo que haya en el editor y pulsa **Guardar**.
+
+</details>
+
+<details>
+<summary><b>📦 Migrar desde InfluxDB, LTSS, el recorder o Scribe 2.x</b></summary>
+<br>
+
+### Actualizar desde Scribe 2.x
+
+Scribe 3.0 sustituyó la tabla `states` por `states_raw` más una vista de
+compatibilidad, y dio a `entities` una clave primaria numérica. La conversión de
+una base antigua la hacían las versiones 3.x y se **eliminó en la 3.9**.
+
+Si tu base de datos todavía tiene una *tabla* `states` (en lugar de una vista),
+una tabla `states_legacy`, o una tabla `entities` sin columna `id`, Scribe se
+detiene al arrancar, no registra nada y genera un problema en Reparaciones, sin
+renombrar, crear ni eliminar nada. Instala **Scribe 3.8**, deja Home Assistant
+en marcha hasta que los registros indiquen que la migración ha terminado (unos
+quince minutos en una base grande) y actualiza de nuevo.
+
+Las instalaciones nuevas y cualquier base creada por una versión 3.x no se ven
+afectadas.
+
+### Importar datos desde otras fuentes
+
+Scribe incluye scripts para importar datos desde varias fuentes.
+
+### Migración desde InfluxDB
+
+#### Mostrar la guía de migración de InfluxDB
+
+1. Sitúate en el directorio `migration`:
+   ```bash
+   cd migration
+   ```
+
+2. Instala las dependencias:
+   ```bash
+   pip install influxdb-client psycopg2-binary python-dotenv
+   ```
+
+3. Configura la migración:
+   ```bash
+   cp .env.example .env
+   nano .env
+   # Rellena [InfluxDB Configuration], [Scribe Configuration] y [Migration Settings]
+   ```
+
+4. Ejecuta la migración:
+   ```bash
+   python3 influx2scribe.py
+   ```
+
+
+### Migración desde LTSS
+
+#### Mostrar la guía de migración de LTSS
+
+1. Sitúate en el directorio `migration`:
+   ```bash
+   cd migration
+   ```
+
+2. Instala las dependencias:
+   ```bash
+   pip install psycopg2-binary python-dotenv
+   ```
+
+3. Configura la migración:
+   ```bash
+   cp .env.example .env
+   nano .env
+   # Rellena [LTSS Configuration], [Scribe Configuration] y [Migration Settings]
+   ```
+
+4. Ejecuta la migración:
+   ```bash
+   python3 ltss2scribe.py
+   ```
+
+
+### Migración desde Recorder
+
+#### Mostrar la guía de migración de Recorder
+
+1. Sitúate en el directorio `migration`:
+   ```bash
+   cd migration
+   ```
+
+2. Instala las dependencias:
+   ```bash
+   pip install psycopg2-binary python-dotenv
+   ```
+
+3. Configura la migración:
+   ```bash
+   cp .env.example .env
+   nano .env
+   # Rellena [Recorder Configuration], [Scribe Configuration] y [Migration Settings]
+   ```
+
+4. Ejecuta la migración:
+   ```bash
+   python3 recorder2scribe.py
+   ```
+
+</details>
+
+<details>
+<summary><b>🩺 Solución de problemas</b></summary>
+<br>
 
 ### Lo primero que hay que mirar
 
@@ -701,40 +744,18 @@ Loops), esenciales para el rendimiento de Scribe con grandes volúmenes.
 ### ¿Sigues con problemas?
 [Abre una incidencia](https://github.com/jonathan-gtd/scribe/issues) en GitHub con tus registros y tu configuración. ¡Estaré encantado de ayudar!
 
-## Panel / Vista
+</details>
 
-En este repositorio hay una disposición Lovelace lista para usar con todos los
-sensores útiles de Scribe (estadísticas de la base, ratios de compresión,
-rendimiento de escritura), en dos variantes:
-
-| Archivo | Qué es | Dónde pegarlo |
-| --- | --- | --- |
-| [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml) | Una **sola tarjeta** (`type: vertical-stack`) | El editor YAML de tarjeta («Añadir tarjeta» → «Manual») |
-| [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml) | Una **vista completa** (`title` / `icon` / `cards`) | El editor YAML de vista |
-
-> ⚠️ No son intercambiables. Pegar el archivo de *vista* en un editor de
-> *tarjeta* falla con **«No card type configured»**, porque la configuración de
-> una tarjeta debe empezar por una clave `type:`.
-
-**Opción A — añadirla como tarjeta (lo más fácil, funciona en cualquier tipo de vista):**
-
-1.  Abre tu panel y pulsa «Editar panel» (icono del lápiz).
-2.  Pulsa **+ Añadir tarjeta** y baja hasta el final del selector para elegir **Manual**.
-3.  Copia el contenido de [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml), sustituye todo lo que haya en el editor y pulsa **Guardar**.
-
-**Opción B — añadirla como vista dedicada:**
-
-1.  Abre tu panel y pulsa «Editar panel» (icono del lápiz).
-2.  Pulsa el botón **+** *en la barra de pestañas superior* (junto a los nombres de tus vistas) para añadir una vista, no el botón «Añadir tarjeta».
-3.  En el diálogo de la vista, abre el menú ⋮ (o el botón «Mostrar editor de código») y elige **Editar en YAML**.
-4.  Copia el contenido de [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml), sustituye todo lo que haya en el editor y pulsa **Guardar**.
-
-## Ecosistema / Proyectos relacionados
+<details>
+<summary><b>🔗 Proyectos relacionados</b></summary>
+<br>
 
 Estos proyectos funcionan muy bien con Scribe:
 
 - [timescale_database_reader](https://github.com/remmob/timescale_database_reader): un componente personalizado para volver a leer datos de TimescaleDB en sensores de Home Assistant.
 - [timescale-plotly-card](https://github.com/remmob/timescale-plotly-card): una tarjeta basada en Plotly, muy personalizable, capaz de consultar TimescaleDB directamente.
+
+</details>
 
 ## Licencia
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,64 +1,54 @@
-[🇬🇧 English](README.md) · **🇫🇷 Français** · [🇪🇸 Español](README.es.md) · [🇩🇪 Deutsch](README.de.md)
+<div align="center">
 
-# Scribe — Intégration TimescaleDB haute performance pour Home Assistant
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="brands_assets/dark_logo.png">
+  <img src="brands_assets/logo.png" alt="Scribe" width="300">
+</picture>
 
-Scribe est un composant de nouvelle génération qui écrit les états et les événements de Home Assistant dans une base de données TimescaleDB.
+### L'historique de Home Assistant dans TimescaleDB
 
-**Pourquoi Scribe ?**
-Scribe est conçu différemment. Contrairement aux intégrations qui reposent sur des pilotes synchrones ou sur le recorder par défaut, Scribe utilise **`asyncpg`**, un pilote PostgreSQL asynchrone très performant. Il peut ainsi absorber d'énormes volumes de données sans bloquer la boucle d'événements de Home Assistant. Il est pensé pour la stabilité, la vitesse et l'efficacité.
+Chaque état et chaque événement, via `asyncpg` — sans bloquer la boucle d'événements.
 
-**Structure des données et requêtes**
+[![Release](https://img.shields.io/github/v/release/jonathan-gtd/scribe?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases/latest) [![Downloads](https://img.shields.io/github/downloads/jonathan-gtd/scribe/total?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases) [![Tests](https://img.shields.io/github/actions/workflow/status/jonathan-gtd/scribe/tests.yaml?branch=master&label=tests)](https://github.com/jonathan-gtd/scribe/actions/workflows/tests.yaml) [![License](https://img.shields.io/github/license/jonathan-gtd/scribe?color=lightgrey)](LICENSE)
 
-Une explication de la structure des données et de la façon de l'interroger se trouve ici : [Structure des données](docs/data-structure.md)
+[![lang en](https://img.shields.io/badge/lang-en-lightgrey)](README.md) [![lang fr](https://img.shields.io/badge/lang-fr-41BDF5)](README.fr.md) [![lang es](https://img.shields.io/badge/lang-es-lightgrey)](README.es.md) [![lang de](https://img.shields.io/badge/lang-de-lightgrey)](README.de.md)
 
-## Table des matières
+</div>
 
-- [Fonctionnalités](#fonctionnalités)
-- [Installation](#installation)
-- [Configuration](#configuration)
-- [Réglage du stockage](#réglage-du-stockage)
-- [Rétention](#rétention)
-- [Résumés](#résumés)
-- [Schéma de la base de données](#schéma-de-la-base-de-données)
-- [Migration](#migration)
-- [Capteurs de statistiques](#capteurs-de-statistiques)
-- [Services](#services)
-- [Tableau de bord / Vue](#tableau-de-bord--vue)
-- [Écosystème / Projets liés](#écosystème--projets-liés)
-- [Dépannage](#dépannage)
-- [Licence](#licence)
+---
 
-## Fonctionnalités
+Le recorder de Home Assistant garde quelques semaines d'historique dans SQLite et ralentit à mesure qu'il grossit. Scribe écrit les mêmes états et événements dans **TimescaleDB**, où des années restent rapides et occupent une fraction de la place.
 
-- 🚀 **Architecture asynchrone d'abord** : bâtie sur `asyncpg` pour des écritures non bloquantes et à haut débit.
-- 📦 **TimescaleDB natif** : gère automatiquement les hypertables et les politiques de compression.
-- 📊 **Statistiques détaillées** : capteurs optionnels pour suivre le nombre de chunks, les taux de compression (jusqu'à 97 % d'économie !) et les performances d'écriture.
-- 🔒 **Sécurisé** : prise en charge complète de SSL/TLS.
-- 📈 **États et événements** : enregistre tous les changements d'état et les événements dans les tables `states` et `events`.
-- 👥 **Contexte utilisateur** : synchronise automatiquement les utilisateurs de Home Assistant dans la base pour un contexte plus riche.
-- 🧩 **Métadonnées des entités** : synchronise automatiquement le registre des entités (noms, plateformes, etc.) dans la table `entities`.
-- 🏠 **Contexte pièces et appareils** : synchronise automatiquement les pièces et les appareils dans les tables `areas` et `devices`.
-- 🔌 **Informations d'intégration** : synchronise automatiquement les entrées de configuration des intégrations dans la table `integrations`.
-- 🎯 **Filtrage fin** : inclusion/exclusion par domaine, entité, motif d'entité ou attribut.
-- ✅ **Testé contre une vraie base** : ~90 % de couverture de lignes, et une suite de bout en bout qui pilote l'intégration contre une vraie TimescaleDB plutôt que des mocks.
+- 🚀 **Asynchrone de bout en bout** — `asyncpg` et des `COPY` par lots : l'enregistrement ne bloque jamais Home Assistant.
+- 🗜️ **Compressé automatiquement** — l'historique ancien est découpé en chunks et compressé, typiquement 10× plus petit.
+- 🛟 **Rien n'est perdu** — une base indisponible est mise en tampon, puis écrite à son retour.
+- 🧩 **Le contexte avec** — entités, appareils, pièces, utilisateurs et intégrations, pas seulement des valeurs.
+- 🩺 **Il dit quand quelque chose ne va pas**, dans Repairs plutôt que dans un journal que personne ne lit.
 
 ## Installation
 
-### 1. Installer le composant
+**1. Une base TimescaleDB.** L'extension est obligatoire — voir *Installer TimescaleDB* plus bas.
 
-**HACS (recommandé)**
+**2. Scribe, via HACS :**
 
-[![Ouvrir votre instance Home Assistant et ouvrir un dépôt dans le Home Assistant Community Store.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jonathan-gtd&repository=scribe&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jonathan-gtd&repository=scribe&category=integration)
 
-1. Ajoutez ce dépôt comme dépôt personnalisé dans HACS.
-2. Cherchez « Scribe » et installez-le.
-3. Redémarrez Home Assistant.
+*Ou à la main :* copiez `custom_components/scribe` dans votre dossier `custom_components`. Dans les deux cas, redémarrez Home Assistant.
 
-**Manuel**
-1. Copiez le dossier `custom_components/scribe` dans le répertoire `custom_components` de votre Home Assistant.
-2. Redémarrez Home Assistant.
+**3. L'URL de la base**, dans `configuration.yaml` :
 
-### 2. Mise en place de la base de données
+```yaml
+scribe:
+  db_url: "postgresql://scribe:password@192.168.1.10:5432/scribe"
+```
+
+Voilà — les états sont enregistrés, découpés et compressés, avec le contexte entité, appareil et pièce. Tout ce qui suit est facultatif.
+
+<details>
+<summary><b>🗄️ Installer TimescaleDB</b></summary>
+<br>
+
+### Mise en place de la base de données
 
 Il vous faut une instance TimescaleDB en fonctionnement. Je recommande PostgreSQL 17 ou 18.
 
@@ -100,19 +90,15 @@ CREATE EXTENSION IF NOT EXISTS timescaledb;
 GRANT ALL ON SCHEMA public TO scribe;
 ```
 
-## Configuration
+</details>
 
-### Configuration minimale
-
-```yaml
-scribe:
-  db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
-```
+<details>
+<summary><b>⚙️ Toutes les options, avec leurs valeurs par défaut</b></summary>
+<br>
 
 ### Configuration complète (valeurs par défaut)
 
-<details>
-<summary><b>Afficher la configuration YAML complète</b></summary>
+#### Afficher la configuration YAML complète
 
 ```yaml
 scribe:
@@ -156,12 +142,14 @@ scribe:
   enable_table_users: true
   enable_rollups: false
 ```
+
 </details>
 
-### Paramètres de configuration
-
 <details>
-<summary><b>Afficher la référence des paramètres</b></summary>
+<summary><b>📋 Référence des paramètres</b></summary>
+<br>
+
+#### Afficher la référence des paramètres
 
 | Paramètre | Description |
 | :--- | :--- |
@@ -203,9 +191,12 @@ scribe:
 | `enable_table_integrations` | Activer la création et la synchronisation de la table `integrations`. |
 | `enable_table_users` | Activer la création et la synchronisation de la table `users`. |
 | `enable_rollups` | Conserver des résumés horaires et journaliers pré-calculés des états (`states_hourly`, `states_daily`). Désactivé par défaut. |
+
 </details>
 
-## Réglage du stockage
+<details>
+<summary><b>🗜️ Réglage du stockage — chunks et compression</b></summary>
+<br>
 
 Scribe range l'historique dans des **hypertables** TimescaleDB : une table qui
 s'utilise et s'interroge comme n'importe quelle autre, mais qui est
@@ -279,7 +270,11 @@ Si les capteurs de taille et de chunks sont activés (`enable_stats_size`,
 `enable_stats_chunk`), ils rapportent exactement ce que ces réglages produisent :
 nombre de chunks, tailles compressée et non compressée, taux de compression.
 
-## Rétention
+</details>
+
+<details>
+<summary><b>🧹 Rétention — supprimer l'historique ancien automatiquement</b></summary>
+<br>
 
 Par défaut, Scribe conserve tout, indéfiniment. Si vous ne voulez garder qu'une
 fenêtre bornée — parce que vous agrégez l'historique brut ailleurs, ou
@@ -332,7 +327,11 @@ Ce qu'il faut savoir :
   `1 year`. Toute autre valeur est refusée avec une erreur plutôt qu'envoyée à
   la base.
 
-## Résumés
+</details>
+
+<details>
+<summary><b>📈 Résumés — agrégats horaires et journaliers</b></summary>
+<br>
 
 Un an d'un capteur qui remonte une valeur toutes les 30 secondes, c'est environ un million de lignes. Un graphique sur cette année les lit toutes, à chaque affichage.
 
@@ -362,7 +361,11 @@ Seuls les états numériques sont résumés — la moyenne de `on` et `off` n'a 
 
 **Ce sont des données dérivées.** Rien de ce qui compte n'est dupliqué : désactiver l'option supprime les deux vues, la réactiver les reconstruit depuis l'historique, et vos états ne sont jamais touchés. TimescaleDB les maintient lui-même ; Scribe se contente de les créer.
 
-## Schéma de la base de données
+</details>
+
+<details>
+<summary><b>🗃️ Schéma de la base — tables, vues et comment les interroger</b></summary>
+<br>
 
 Par défaut, Scribe enregistre dans le schéma vers lequel votre connexion pointe
 déjà — normalement `public`. Renseignez `db_schema` et il crée ce schéma et y
@@ -416,173 +419,11 @@ distinctes — et rien de ce que Scribe fait dans l'un n'atteint l'autre.
   vous-même avec `?options=-csearch_path%3Dmonschema` dans l'URL, que Scribe
   suit sans le remplacer.
 
-## Migration
-
-### Mise à jour depuis Scribe 2.x
-
-Scribe 3.0 a remplacé la table `states` par `states_raw` accompagnée d'une vue de
-compatibilité, et a donné à `entities` une clé primaire numérique. La conversion
-d'une ancienne base était assurée par les versions 3.x et a été **supprimée en
-3.9**.
-
-Si votre base contient encore une *table* `states` (et non une vue), une table
-`states_legacy`, ou une table `entities` sans colonne `id`, Scribe s'arrête au
-démarrage, n'enregistre rien et signale un problème dans Repairs — sans rien
-renommer, créer ni supprimer. Installez **Scribe 3.8**, laissez Home Assistant
-tourner jusqu'à ce que les logs annoncent la fin de la migration (une quinzaine
-de minutes sur une grosse base), puis remettez à jour.
-
-Les installations neuves et toute base créée par une version 3.x ne sont pas
-concernées.
-
-### Reprise de données depuis d'autres sources
-
-Scribe fournit des scripts pour reprendre des données depuis diverses sources.
-
-### Migration InfluxDB
-
-<details>
-<summary><b>Afficher le guide de migration InfluxDB</b></summary>
-
-1. Placez-vous dans le répertoire `migration` :
-   ```bash
-   cd migration
-   ```
-
-2. Installez les dépendances :
-   ```bash
-   pip install influxdb-client psycopg2-binary python-dotenv
-   ```
-
-3. Configurez la migration :
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Renseignez [InfluxDB Configuration], [Scribe Configuration] et [Migration Settings]
-   ```
-
-4. Lancez la migration :
-   ```bash
-   python3 influx2scribe.py
-   ```
 </details>
 
-### Migration LTSS
-
 <details>
-<summary><b>Afficher le guide de migration LTSS</b></summary>
-
-1. Placez-vous dans le répertoire `migration` :
-   ```bash
-   cd migration
-   ```
-
-2. Installez les dépendances :
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Configurez la migration :
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Renseignez [LTSS Configuration], [Scribe Configuration] et [Migration Settings]
-   ```
-
-4. Lancez la migration :
-   ```bash
-   python3 ltss2scribe.py
-   ```
-</details>
-
-### Migration Recorder
-
-<details>
-<summary><b>Afficher le guide de migration Recorder</b></summary>
-
-1. Placez-vous dans le répertoire `migration` :
-   ```bash
-   cd migration
-   ```
-
-2. Installez les dépendances :
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Configurez la migration :
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Renseignez [Recorder Configuration], [Scribe Configuration] et [Migration Settings]
-   ```
-
-4. Lancez la migration :
-   ```bash
-   python3 recorder2scribe.py
-   ```
-</details>
-
-## Capteurs de statistiques
-
-Activez les capteurs en positionnant leurs options dans votre configuration.
-
-### Statistiques d'écriture (`enable_stats_io: true`)
-
-<details>
-<summary><b>Afficher les capteurs d'écriture</b></summary>
-
-Mesures en temps réel issues de l'écrivain (aucune requête en base).
-
-| Capteur | Description |
-| :--- | :--- |
-| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_states_written` | Nombre total de changements d'état écrits en base. |
-| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_events_written` | Nombre total d'événements écrits en base. |
-| <img src="https://api.iconify.design/mdi:buffer.svg?color=%232196F3" width="15" /> `sensor.scribe_buffer_size` | Nombre d'éléments actuellement en attente dans le tampon mémoire. |
-| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_write_duration` | Durée (en ms) de la dernière écriture en base. |
-| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_states_rate` | Débit d'états écrits en base (par minute). |
-| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_events_rate` | Débit d'événements écrits en base (par minute). |
-</details>
-
-### Statistiques de chunks (`enable_stats_chunk: true`)
-
-<details>
-<summary><b>Afficher les capteurs de chunks</b></summary>
-
-Nombre de chunks (mis à jour toutes les `stats_chunk_interval` minutes).
-
-| Capteur | Description |
-| :--- | :--- |
-| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_chunks` | Nombre total de chunks de la table des états. |
-| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_chunks` | Nombre de chunks déjà compressés. |
-| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_chunks` | Nombre de chunks en attente de compression. |
-| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_chunks` | Nombre total de chunks de la table des événements. |
-| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_chunks` | Nombre de chunks d'événements compressés. |
-| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_chunks` | Nombre de chunks d'événements non compressés. |
-</details>
-
-### Statistiques de taille (`enable_stats_size: true`)
-
-<details>
-<summary><b>Afficher les capteurs de taille</b></summary>
-
-Espace occupé, en octets (mis à jour toutes les `stats_size_interval` minutes).
-
-| Capteur | Description |
-| :--- | :--- |
-| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_size` | Taille totale sur disque (données compressées + chunks récents + index). |
-| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_states_original_size` | **Taille théorique** si les données n'étaient pas compressées (ex. 11 Go). |
-| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_size` | Taille physique des chunks de données compressés. |
-| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_size` | Taille des données récentes pas encore compressées (ou index en attente). |
-| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compression_ratio` | Taux de compression des états (%). |
-| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_size` | Taille totale sur disque de la table des événements. |
-| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_events_original_size` | Taille théorique des événements avant compression. |
-| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_size` | Taille des données d'événements compressées. |
-| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_size` | Taille des données d'événements non compressées. |
-| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compression_ratio` | Taux de compression des événements (%). |
-</details>
-
-## Services
+<summary><b>🛠️ Services — flush, query, purge</b></summary>
+<br>
 
 ### `scribe.flush`
 Force l'écriture immédiate en base des données en tampon.
@@ -637,7 +478,209 @@ response_variable: purged
 
 L'historique compressé est purgé lui aussi : TimescaleDB s'en charge et les chunks restent compressés. Pour une fenêtre glissante appliquée en continu, utilisez plutôt les réglages de [rétention](#rétention) : une purge est ponctuelle.
 
-## Dépannage
+</details>
+
+<details>
+<summary><b>📊 Capteurs de statistiques</b></summary>
+<br>
+
+Activez les capteurs en positionnant leurs options dans votre configuration.
+
+### Statistiques d'écriture (`enable_stats_io: true`)
+
+#### Afficher les capteurs d'écriture
+
+Mesures en temps réel issues de l'écrivain (aucune requête en base).
+
+| Capteur | Description |
+| :--- | :--- |
+| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_states_written` | Nombre total de changements d'état écrits en base. |
+| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_events_written` | Nombre total d'événements écrits en base. |
+| <img src="https://api.iconify.design/mdi:buffer.svg?color=%232196F3" width="15" /> `sensor.scribe_buffer_size` | Nombre d'éléments actuellement en attente dans le tampon mémoire. |
+| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_write_duration` | Durée (en ms) de la dernière écriture en base. |
+| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_states_rate` | Débit d'états écrits en base (par minute). |
+| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_events_rate` | Débit d'événements écrits en base (par minute). |
+
+
+### Statistiques de chunks (`enable_stats_chunk: true`)
+
+#### Afficher les capteurs de chunks
+
+Nombre de chunks (mis à jour toutes les `stats_chunk_interval` minutes).
+
+| Capteur | Description |
+| :--- | :--- |
+| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_chunks` | Nombre total de chunks de la table des états. |
+| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_chunks` | Nombre de chunks déjà compressés. |
+| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_chunks` | Nombre de chunks en attente de compression. |
+| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_chunks` | Nombre total de chunks de la table des événements. |
+| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_chunks` | Nombre de chunks d'événements compressés. |
+| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_chunks` | Nombre de chunks d'événements non compressés. |
+
+
+### Statistiques de taille (`enable_stats_size: true`)
+
+#### Afficher les capteurs de taille
+
+Espace occupé, en octets (mis à jour toutes les `stats_size_interval` minutes).
+
+| Capteur | Description |
+| :--- | :--- |
+| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_size` | Taille totale sur disque (données compressées + chunks récents + index). |
+| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_states_original_size` | **Taille théorique** si les données n'étaient pas compressées (ex. 11 Go). |
+| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_size` | Taille physique des chunks de données compressés. |
+| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_size` | Taille des données récentes pas encore compressées (ou index en attente). |
+| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compression_ratio` | Taux de compression des états (%). |
+| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_size` | Taille totale sur disque de la table des événements. |
+| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_events_original_size` | Taille théorique des événements avant compression. |
+| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_size` | Taille des données d'événements compressées. |
+| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_size` | Taille des données d'événements non compressées. |
+| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compression_ratio` | Taux de compression des événements (%). |
+
+</details>
+
+<details>
+<summary><b>🖼️ Tableau de bord</b></summary>
+<br>
+
+Une mise en page Lovelace prête à l'emploi rassemblant tous les capteurs utiles
+de Scribe (statistiques de base, taux de compression, performances d'écriture)
+est disponible dans ce dépôt, en deux variantes :
+
+| Fichier | Ce que c'est | Où le coller |
+| --- | --- | --- |
+| [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml) | Une **carte unique** (`type: vertical-stack`) | L'éditeur YAML de carte (« Ajouter une carte » → « Manuel ») |
+| [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml) | Une **vue entière** (`title` / `icon` / `cards`) | L'éditeur YAML de vue |
+
+> ⚠️ Les deux ne sont pas interchangeables. Coller le fichier de *vue* dans un
+> éditeur de *carte* échoue avec **« Aucun type de carte configuré »**, car une
+> configuration de carte doit commencer par une clé `type:`.
+
+**Option A — l'ajouter comme carte (le plus simple, fonctionne dans tous les types de vue) :**
+
+1.  Ouvrez votre tableau de bord et cliquez sur « Modifier le tableau de bord » (icône crayon).
+2.  Cliquez sur **+ Ajouter une carte** et descendez tout en bas du sélecteur pour choisir **Manuel**.
+3.  Copiez le contenu de [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml), remplacez tout ce qui se trouve dans l'éditeur, puis cliquez sur **Enregistrer**.
+
+**Option B — l'ajouter comme vue dédiée :**
+
+1.  Ouvrez votre tableau de bord et cliquez sur « Modifier le tableau de bord » (icône crayon).
+2.  Cliquez sur le bouton **+** *dans la barre d'onglets du haut* (à côté du nom de vos vues) pour ajouter une vue — et non sur le bouton « Ajouter une carte ».
+3.  Dans la boîte de dialogue de la vue, ouvrez le menu ⋮ (ou le bouton « Afficher l'éditeur de code ») et choisissez **Modifier en YAML**.
+4.  Copiez le contenu de [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml), remplacez tout ce qui se trouve dans l'éditeur, puis cliquez sur **Enregistrer**.
+
+</details>
+
+<details>
+<summary><b>📦 Migrer depuis InfluxDB, LTSS, le recorder ou Scribe 2.x</b></summary>
+<br>
+
+### Mise à jour depuis Scribe 2.x
+
+Scribe 3.0 a remplacé la table `states` par `states_raw` accompagnée d'une vue de
+compatibilité, et a donné à `entities` une clé primaire numérique. La conversion
+d'une ancienne base était assurée par les versions 3.x et a été **supprimée en
+3.9**.
+
+Si votre base contient encore une *table* `states` (et non une vue), une table
+`states_legacy`, ou une table `entities` sans colonne `id`, Scribe s'arrête au
+démarrage, n'enregistre rien et signale un problème dans Repairs — sans rien
+renommer, créer ni supprimer. Installez **Scribe 3.8**, laissez Home Assistant
+tourner jusqu'à ce que les logs annoncent la fin de la migration (une quinzaine
+de minutes sur une grosse base), puis remettez à jour.
+
+Les installations neuves et toute base créée par une version 3.x ne sont pas
+concernées.
+
+### Reprise de données depuis d'autres sources
+
+Scribe fournit des scripts pour reprendre des données depuis diverses sources.
+
+### Migration InfluxDB
+
+#### Afficher le guide de migration InfluxDB
+
+1. Placez-vous dans le répertoire `migration` :
+   ```bash
+   cd migration
+   ```
+
+2. Installez les dépendances :
+   ```bash
+   pip install influxdb-client psycopg2-binary python-dotenv
+   ```
+
+3. Configurez la migration :
+   ```bash
+   cp .env.example .env
+   nano .env
+   # Renseignez [InfluxDB Configuration], [Scribe Configuration] et [Migration Settings]
+   ```
+
+4. Lancez la migration :
+   ```bash
+   python3 influx2scribe.py
+   ```
+
+
+### Migration LTSS
+
+#### Afficher le guide de migration LTSS
+
+1. Placez-vous dans le répertoire `migration` :
+   ```bash
+   cd migration
+   ```
+
+2. Installez les dépendances :
+   ```bash
+   pip install psycopg2-binary python-dotenv
+   ```
+
+3. Configurez la migration :
+   ```bash
+   cp .env.example .env
+   nano .env
+   # Renseignez [LTSS Configuration], [Scribe Configuration] et [Migration Settings]
+   ```
+
+4. Lancez la migration :
+   ```bash
+   python3 ltss2scribe.py
+   ```
+
+
+### Migration Recorder
+
+#### Afficher le guide de migration Recorder
+
+1. Placez-vous dans le répertoire `migration` :
+   ```bash
+   cd migration
+   ```
+
+2. Installez les dépendances :
+   ```bash
+   pip install psycopg2-binary python-dotenv
+   ```
+
+3. Configurez la migration :
+   ```bash
+   cp .env.example .env
+   nano .env
+   # Renseignez [Recorder Configuration], [Scribe Configuration] et [Migration Settings]
+   ```
+
+4. Lancez la migration :
+   ```bash
+   python3 recorder2scribe.py
+   ```
+
+</details>
+
+<details>
+<summary><b>🩺 Dépannage</b></summary>
+<br>
 
 ### À regarder en premier
 
@@ -707,40 +750,18 @@ volumes.
 ### Toujours bloqué ?
 [Ouvrez un ticket](https://github.com/jonathan-gtd/scribe/issues) sur GitHub avec vos logs et votre configuration. Je serai ravi de vous aider !
 
-## Tableau de bord / Vue
+</details>
 
-Une mise en page Lovelace prête à l'emploi rassemblant tous les capteurs utiles
-de Scribe (statistiques de base, taux de compression, performances d'écriture)
-est disponible dans ce dépôt, en deux variantes :
-
-| Fichier | Ce que c'est | Où le coller |
-| --- | --- | --- |
-| [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml) | Une **carte unique** (`type: vertical-stack`) | L'éditeur YAML de carte (« Ajouter une carte » → « Manuel ») |
-| [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml) | Une **vue entière** (`title` / `icon` / `cards`) | L'éditeur YAML de vue |
-
-> ⚠️ Les deux ne sont pas interchangeables. Coller le fichier de *vue* dans un
-> éditeur de *carte* échoue avec **« Aucun type de carte configuré »**, car une
-> configuration de carte doit commencer par une clé `type:`.
-
-**Option A — l'ajouter comme carte (le plus simple, fonctionne dans tous les types de vue) :**
-
-1.  Ouvrez votre tableau de bord et cliquez sur « Modifier le tableau de bord » (icône crayon).
-2.  Cliquez sur **+ Ajouter une carte** et descendez tout en bas du sélecteur pour choisir **Manuel**.
-3.  Copiez le contenu de [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml), remplacez tout ce qui se trouve dans l'éditeur, puis cliquez sur **Enregistrer**.
-
-**Option B — l'ajouter comme vue dédiée :**
-
-1.  Ouvrez votre tableau de bord et cliquez sur « Modifier le tableau de bord » (icône crayon).
-2.  Cliquez sur le bouton **+** *dans la barre d'onglets du haut* (à côté du nom de vos vues) pour ajouter une vue — et non sur le bouton « Ajouter une carte ».
-3.  Dans la boîte de dialogue de la vue, ouvrez le menu ⋮ (ou le bouton « Afficher l'éditeur de code ») et choisissez **Modifier en YAML**.
-4.  Copiez le contenu de [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml), remplacez tout ce qui se trouve dans l'éditeur, puis cliquez sur **Enregistrer**.
-
-## Écosystème / Projets liés
+<details>
+<summary><b>🔗 Projets liés</b></summary>
+<br>
 
 Ces projets fonctionnent très bien avec Scribe :
 
 - [timescale_database_reader](https://github.com/remmob/timescale_database_reader) : un composant personnalisé pour relire les données de TimescaleDB dans des capteurs Home Assistant.
 - [timescale-plotly-card](https://github.com/remmob/timescale-plotly-card) : une carte Plotly très personnalisable, capable d'interroger TimescaleDB directement.
+
+</details>
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 <div align="center">
 
-<img src="brands_assets/logo.png" alt="Scribe" width="320">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="brands_assets/dark_logo.png">
+  <img src="brands_assets/logo.png" alt="Scribe" width="300">
+</picture>
 
 ### Home Assistant history in TimescaleDB
 
-Every state and every event, written through `asyncpg` — without blocking the event loop.
+Every state and every event, through `asyncpg` — without blocking the event loop.
 
-[![HACS Default](https://img.shields.io/badge/HACS-Default-41BDF5.svg)](https://github.com/hacs/integration) [![Release](https://img.shields.io/github/v/release/jonathan-gtd/scribe?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases/latest) [![Downloads](https://img.shields.io/github/downloads/jonathan-gtd/scribe/total?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases) [![Tests](https://img.shields.io/github/actions/workflow/status/jonathan-gtd/scribe/tests.yaml?branch=master&label=tests)](https://github.com/jonathan-gtd/scribe/actions/workflows/tests.yaml) [![License](https://img.shields.io/github/license/jonathan-gtd/scribe?color=lightgrey)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/jonathan-gtd/scribe?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases/latest) [![Downloads](https://img.shields.io/github/downloads/jonathan-gtd/scribe/total?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases) [![Tests](https://img.shields.io/github/actions/workflow/status/jonathan-gtd/scribe/tests.yaml?branch=master&label=tests)](https://github.com/jonathan-gtd/scribe/actions/workflows/tests.yaml) [![License](https://img.shields.io/github/license/jonathan-gtd/scribe?color=lightgrey)](LICENSE)
 
 [![lang en](https://img.shields.io/badge/lang-en-41BDF5)](README.md) [![lang fr](https://img.shields.io/badge/lang-fr-lightgrey)](README.fr.md) [![lang es](https://img.shields.io/badge/lang-es-lightgrey)](README.es.md) [![lang de](https://img.shields.io/badge/lang-de-lightgrey)](README.de.md)
 
@@ -14,31 +17,35 @@ Every state and every event, written through `asyncpg` — without blocking the 
 
 ---
 
-Home Assistant's recorder keeps a few weeks of history in SQLite and slows down as it grows. Scribe writes the same states and events to **TimescaleDB**, where years of history stay fast and take a fraction of the space.
+Home Assistant's recorder keeps a few weeks of history in SQLite and slows down as it grows. Scribe writes the same states and events to **TimescaleDB**, where years stay fast and take a fraction of the space.
 
-- **Asynchronous end to end** — `asyncpg` and batched `COPY`, so recording never blocks Home Assistant.
-- **Compressed automatically** — TimescaleDB chunks and compresses old history, typically 10× smaller.
-- **Nothing is lost** — a database that is down is buffered, and written when it returns.
-- **Context included** — entities, devices, areas, users and integrations, not only values.
-- **It says when something is wrong**, in Repairs, instead of in a log nobody reads.
+- 🚀 **Asynchronous end to end** — `asyncpg` and batched `COPY`: recording never blocks Home Assistant.
+- 🗜️ **Compressed automatically** — old history is chunked and compressed, typically 10× smaller.
+- 🛟 **Nothing is lost** — a database that is down is buffered, then written when it returns.
+- 🧩 **Context included** — entities, devices, areas, users and integrations, not only values.
+- 🩺 **It says when something is wrong**, in Repairs rather than in a log nobody reads.
 
 ## Install
 
+**1. A TimescaleDB database.** The extension is required — see *Setting up TimescaleDB* below.
+
+**2. Scribe, through HACS:**
+
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jonathan-gtd&repository=scribe&category=integration)
 
-1. **A TimescaleDB database** — the extension is required; see *Setting up TimescaleDB* below.
-2. **Scribe, through HACS** — the button above, then *Download*, then restart Home Assistant.
-3. **The database URL**, in `configuration.yaml`:
+*Or by hand:* copy `custom_components/scribe` into your `custom_components` folder. Either way, restart Home Assistant.
+
+**3. The database URL**, in `configuration.yaml`:
 
 ```yaml
 scribe:
   db_url: "postgresql://scribe:password@192.168.1.10:5432/scribe"
 ```
 
-That is a working installation: states are recorded, chunked and compressed, with the entity, device and area context alongside them. Everything below is optional.
+Done — states recorded, chunked and compressed, with their entity, device and area context. Everything below is optional.
 
 <details>
-<summary><b>Setting up TimescaleDB</b></summary>
+<summary><b>🗄️ Setting up TimescaleDB</b></summary>
 <br>
 
 You need a running TimescaleDB instance. I recommend PostgreSQL 17 or 18.
@@ -83,7 +90,7 @@ GRANT ALL ON SCHEMA public TO scribe;
 </details>
 
 <details>
-<summary><b>Every option, with its defaults</b></summary>
+<summary><b>⚙️ Every option, with its defaults</b></summary>
 <br>
 
 ### Full Configuration (Default Values)
@@ -136,7 +143,7 @@ scribe:
 </details>
 
 <details>
-<summary><b>Parameter reference</b></summary>
+<summary><b>📋 Parameter reference</b></summary>
 <br>
 
 #### Show Parameter Reference
@@ -185,7 +192,7 @@ scribe:
 </details>
 
 <details>
-<summary><b>Storage tuning — chunks and compression</b></summary>
+<summary><b>🗜️ Storage tuning — chunks and compression</b></summary>
 <br>
 
 Scribe stores history in TimescaleDB **hypertables**: a table that looks and
@@ -256,7 +263,7 @@ counts, compressed and uncompressed sizes, and the compression ratio.
 </details>
 
 <details>
-<summary><b>Retention — dropping old history on a schedule</b></summary>
+<summary><b>🧹 Retention — dropping old history on a schedule</b></summary>
 <br>
 
 By default Scribe keeps everything, forever. If you only want to store a bounded
@@ -307,7 +314,7 @@ Details worth knowing:
 </details>
 
 <details>
-<summary><b>Summaries — hourly and daily rollups</b></summary>
+<summary><b>📈 Summaries — hourly and daily rollups</b></summary>
 <br>
 
 A year of a sensor that reports every 30 seconds is about a million rows. A chart of that year reads every one of them, every time it is drawn.
@@ -341,7 +348,7 @@ Only numeric states are summarised — the average of `on` and `off` means nothi
 </details>
 
 <details>
-<summary><b>Database schema — tables, views and how to query them</b></summary>
+<summary><b>🗃️ Database schema — tables, views and how to query them</b></summary>
 <br>
 
 By default Scribe records into whatever schema your connection already points
@@ -398,7 +405,7 @@ Details worth knowing:
 </details>
 
 <details>
-<summary><b>Services — flush, query, purge</b></summary>
+<summary><b>🛠️ Services — flush, query, purge</b></summary>
 <br>
 
 ### `scribe.flush`
@@ -457,7 +464,7 @@ Compressed history is purged as well; TimescaleDB handles it, and the chunks sta
 </details>
 
 <details>
-<summary><b>Statistics sensors</b></summary>
+<summary><b>📊 Statistics sensors</b></summary>
 <br>
 
 Enable sensors by setting their flags in your configuration.
@@ -516,7 +523,7 @@ Storage usage in bytes (updated every `stats_size_interval` minutes).
 </details>
 
 <details>
-<summary><b>Dashboard</b></summary>
+<summary><b>🖼️ Dashboard</b></summary>
 <br>
 
 A pre-configured Lovelace layout containing all useful Scribe sensors (Database Statistics, Compression Ratios, I/O Performance) is available in this repository, in two flavours:
@@ -544,7 +551,7 @@ A pre-configured Lovelace layout containing all useful Scribe sensors (Database 
 </details>
 
 <details>
-<summary><b>Migrating from InfluxDB, LTSS, the recorder or Scribe 2.x</b></summary>
+<summary><b>📦 Migrating from InfluxDB, LTSS, the recorder or Scribe 2.x</b></summary>
 <br>
 
 ### Upgrading from Scribe 2.x
@@ -649,7 +656,7 @@ Scribe provided helper scripts to backfill data from various sources.
 </details>
 
 <details>
-<summary><b>Troubleshooting</b></summary>
+<summary><b>🩺 Troubleshooting</b></summary>
 <br>
 
 ### Before anything else
@@ -714,7 +721,7 @@ Please [open an issue](https://github.com/jonathan-gtd/scribe/issues) on GitHub 
 </details>
 
 <details>
-<summary><b>Related projects</b></summary>
+<summary><b>🔗 Related projects</b></summary>
 <br>
 
 Check out these related projects that work great with Scribe:

--- a/docs/data-structure.md
+++ b/docs/data-structure.md
@@ -15,6 +15,8 @@ Scribe is a long-term storage integration for Home Assistant. It stores entity s
 | `integrations` | Table | HA integrations (platforms) |
 | `users` | Table | HA user accounts |
 | `states` | View | Convenience join of `states_raw` + `entities` |
+| `states_hourly` | View | Hourly summary per entity — only with `enable_rollups` |
+| `states_daily` | View | Daily summary per entity — only with `enable_rollups` |
 
 ---
 
@@ -113,6 +115,36 @@ SELECT s.time, e.entity_id, s.state, s.value, s.attributes
 FROM states_raw s
 JOIN entities e ON e.id = s.metadata_id
 ```
+
+---
+
+### `states_hourly` and `states_daily` — Summaries
+
+Created only when `enable_rollups` is on. They are views over two TimescaleDB **continuous aggregates**, which the database keeps up to date as states arrive. A chart over years reads thousands of rows here instead of millions in `states_raw`.
+
+| Column | Type | Description |
+|---|---|---|
+| `entity_id` | `text` | The entity |
+| `bucket` | `timestamptz` | Start of the hour (or of the day) |
+| `value_avg` | `double precision` | Average of the numeric states in that bucket |
+| `value_min` | `double precision` | Lowest |
+| `value_max` | `double precision` | Highest |
+| `samples` | `bigint` | How many states the row stands for |
+
+Only numeric states are summarised: the average of `on` and `off` means nothing. A bucket with no numeric state has no row.
+
+```sql
+-- Two years of daily temperatures, in one quick query
+SELECT bucket, value_avg, value_min, value_max
+FROM states_daily
+WHERE entity_id = 'sensor.outside_temperature'
+  AND bucket > now() - interval '2 years'
+ORDER BY bucket;
+```
+
+The tables underneath are `states_hourly_raw` and `states_daily_raw`, keyed by `metadata_id` — the same relationship `states_raw` has with `states`. Query the views unless you need the join yourself.
+
+They hold nothing that is not derived from `states_raw`: turning the option off drops them, turning it on rebuilds them from the history.
 
 ---
 


### PR DESCRIPTION
Your four corrections, plus the translations, plus the thing I had missed.

## README

- **The logo is readable on a dark theme.** It is black text on transparent; dark themes now get `brands_assets/dark_logo.png` through a `<picture>`.
- **The HACS badge is gone** — it said nothing the install section does not.
- **The icons are back**, on the five bullets and on every folded section, so the list of subjects reads at a glance.
- **The install leads with HACS**, with the manual copy on one line underneath, and is shorter throughout.

**French, Spanish and German get the same front page**, translated: same badges, same bullets, same three-step install, same folded sections in the same order. 46 visible lines each, against ~650 before.

## `docs/data-structure.md`

You were right, `states_hourly` and `states_daily` were nowhere. They are now in the overview table and have their own section: columns, what a bucket holds, that only numeric states are summarised, an example query over two years, and the `*_raw` aggregates underneath.

The tests that check every YAML option is documented in all four READMEs still pass.