### PR TITLE
docs(readme): show the card, in all four languages

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -45,6 +45,18 @@ scribe:
 Fertig — Zustände werden aufgezeichnet, in Chunks geteilt und komprimiert, mit ihrem Entitäts-, Geräte- und Bereichskontext. Alles Weitere ist optional.
 
 <details>
+<summary><b>🧩 Scribe Card — Diagramme auf Ihrem Dashboard</b></summary>
+<br>
+
+[![Scribe Card](https://raw.githubusercontent.com/jonathan-gtd/scribe-card/master/docs/screenshot.png)](https://github.com/jonathan-gtd/scribe-card)
+
+**[Scribe Card](https://github.com/jonathan-gtd/scribe-card)** bringt jede Abfrage Ihrer Historie auf ein Dashboard. Gezeichnet mit Apache ECharts — der Bibliothek, die auch die Verlaufsdiagramme von Home Assistant nutzen — und in einem Formular konfiguriert, in dem Diagrammtyp, Einheit und Achsen aus den Spalten Ihrer Abfrage gewählt werden.
+
+Sie spricht über den Dienst `scribe.query` mit Scribe: **keine zweite Datenbankverbindung und kein Passwort im Dashboard**. Installation über HACS als benutzerdefiniertes Repository, Kategorie *Dashboard*.
+
+</details>
+
+<details>
 <summary><b>🗄️ TimescaleDB einrichten</b></summary>
 <br>
 
@@ -761,6 +773,7 @@ Loops), die für Scribes Leistung bei großen Datenmengen entscheidend sind.
 
 Diese Projekte harmonieren gut mit Scribe:
 
+- [Scribe Card](https://github.com/jonathan-gtd/scribe-card): die begleitende Karte — jede Abfrage Ihrer Historie, auf einem Dashboard.
 - [timescale_database_reader](https://github.com/remmob/timescale_database_reader): eine benutzerdefinierte Komponente, die Daten aus TimescaleDB zurück in Home-Assistant-Sensoren liest.
 - [timescale-plotly-card](https://github.com/remmob/timescale-plotly-card): eine hochgradig anpassbare Karte auf Plotly-Basis, die TimescaleDB direkt abfragen kann.
 

--- a/README.es.md
+++ b/README.es.md
@@ -45,6 +45,18 @@ scribe:
 Listo — los estados se registran, se dividen en chunks y se comprimen, con su contexto de entidad, dispositivo y área. Todo lo que sigue es opcional.
 
 <details>
+<summary><b>🧩 Scribe Card — gráficos en su panel</b></summary>
+<br>
+
+[![Scribe Card](https://raw.githubusercontent.com/jonathan-gtd/scribe-card/master/docs/screenshot.png)](https://github.com/jonathan-gtd/scribe-card)
+
+**[Scribe Card](https://github.com/jonathan-gtd/scribe-card)** muestra cualquier consulta de su historial en un panel. Dibujada con Apache ECharts —la biblioteca que usan los propios gráficos de historial de Home Assistant— y configurada en un formulario, donde el tipo de gráfico, la unidad y los ejes se eligen entre las columnas que devuelve su consulta.
+
+Usa el servicio `scribe.query`, así que **no hay una segunda conexión a la base de datos que configurar ni una contraseña en su panel**. Instálela mediante HACS como repositorio personalizado, categoría *Panel*.
+
+</details>
+
+<details>
 <summary><b>🗄️ Instalar TimescaleDB</b></summary>
 <br>
 
@@ -752,6 +764,7 @@ Loops), esenciales para el rendimiento de Scribe con grandes volúmenes.
 
 Estos proyectos funcionan muy bien con Scribe:
 
+- [Scribe Card](https://github.com/jonathan-gtd/scribe-card): la tarjeta acompañante — cualquier consulta de su historial, en un panel.
 - [timescale_database_reader](https://github.com/remmob/timescale_database_reader): un componente personalizado para volver a leer datos de TimescaleDB en sensores de Home Assistant.
 - [timescale-plotly-card](https://github.com/remmob/timescale-plotly-card): una tarjeta basada en Plotly, muy personalizable, capaz de consultar TimescaleDB directamente.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -45,6 +45,18 @@ scribe:
 Voilà — les états sont enregistrés, découpés et compressés, avec le contexte entité, appareil et pièce. Tout ce qui suit est facultatif.
 
 <details>
+<summary><b>🧩 Scribe Card — des graphiques sur votre tableau de bord</b></summary>
+<br>
+
+[![Scribe Card](https://raw.githubusercontent.com/jonathan-gtd/scribe-card/master/docs/screenshot.png)](https://github.com/jonathan-gtd/scribe-card)
+
+**[Scribe Card](https://github.com/jonathan-gtd/scribe-card)** affiche n'importe quelle requête de votre historique sur un tableau de bord. Dessinée avec Apache ECharts — la bibliothèque qu'utilisent les graphiques d'historique de Home Assistant — et configurée dans un formulaire, où le type de graphique, l'unité et les axes se choisissent parmi les colonnes que votre requête renvoie.
+
+Elle passe par le service `scribe.query`, donc **aucune seconde connexion à la base à configurer, et aucun mot de passe dans votre tableau de bord**. Installez-la via HACS en dépôt personnalisé, catégorie *Tableau de bord*.
+
+</details>
+
+<details>
 <summary><b>🗄️ Installer TimescaleDB</b></summary>
 <br>
 
@@ -758,6 +770,7 @@ volumes.
 
 Ces projets fonctionnent très bien avec Scribe :
 
+- [Scribe Card](https://github.com/jonathan-gtd/scribe-card) : la carte compagnon — n'importe quelle requête de votre historique, sur un tableau de bord.
 - [timescale_database_reader](https://github.com/remmob/timescale_database_reader) : un composant personnalisé pour relire les données de TimescaleDB dans des capteurs Home Assistant.
 - [timescale-plotly-card](https://github.com/remmob/timescale-plotly-card) : une carte Plotly très personnalisable, capable d'interroger TimescaleDB directement.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ scribe:
 Done — states recorded, chunked and compressed, with their entity, device and area context. Everything below is optional.
 
 <details>
+<summary><b>🧩 Scribe Card — charts on your dashboard</b></summary>
+<br>
+
+[![Scribe Card](https://raw.githubusercontent.com/jonathan-gtd/scribe-card/master/docs/screenshot.png)](https://github.com/jonathan-gtd/scribe-card)
+
+**[Scribe Card](https://github.com/jonathan-gtd/scribe-card)** puts any query from your history on a dashboard. Drawn with Apache ECharts — what Home Assistant's own history charts use — and configured in a form, with the chart type, the unit and the axes picked from the columns your query returns.
+
+It talks to Scribe through the `scribe.query` service, so there is **no second database connection to configure and no password in your dashboard**. Install it through HACS as a custom repository, category *Dashboard*.
+
+</details>
+
+<details>
 <summary><b>🗄️ Setting up TimescaleDB</b></summary>
 <br>
 
@@ -726,6 +738,7 @@ Please [open an issue](https://github.com/jonathan-gtd/scribe/issues) on GitHub 
 
 Check out these related projects that work great with Scribe:
 
+- [Scribe Card](https://github.com/jonathan-gtd/scribe-card): the companion card — any query from your history, on a dashboard.
 - [timescale_database_reader](https://github.com/remmob/timescale_database_reader): A custom component to read data back from TimescaleDB into Home Assistant sensors.
 - [timescale-plotly-card](https://github.com/remmob/timescale-plotly-card): A highly customizable Plotly-based card for Home Assistant that can query TimescaleDB directly.
 


### PR DESCRIPTION
Scribe records a history nobody can see without writing SQL somewhere else. The companion card exists now, and it was buried in a folded list at the bottom of the page.

**It gets a visible section right after the install**, in the four languages: the screenshot, what it does, and the point — it talks to Scribe through `scribe.query`, so there is no second database connection to configure and no password in a dashboard.

It is also listed in *Related projects*, which named everyone else's work and not ours.

Rendered and checked on a dark theme. The README tests still pass.