### PR TITLE
chore: release 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [4.4.0] - 2026-09-12
 
 ### Changed
 - **`scribe.query` cannot take Home Assistant down with it**: the ceiling on a query was two minutes, and there was no ceiling at all on what it could return — `SELECT * FROM states` over a year is tens of millions of rows, loaded into Home Assistant's memory before anything could be done with them. A query now has **60 seconds** and **20 000 rows**, both settable (`query_timeout`, `query_max_rows`) for the reports that genuinely need more; past either, it is refused, and the message says what to do about it (narrow it, group it with `time_bucket()`, add a `LIMIT`). The rows are streamed and counted as they arrive, so a runaway query is stopped rather than held in full and then rejected. Writing is still refused by the read-only transaction the query runs in, which is now covered by tests: `UPDATE`, `DELETE`, `TRUNCATE`, `DROP`, `INSERT`, `CREATE`, `ALTER`, `GRANT`, and two statements in one string.

--- a/custom_components/scribe/manifest.json
+++ b/custom_components/scribe/manifest.json
@@ -14,5 +14,5 @@
         "asyncpg>=0.28.0"
     ],
     "single_config_entry": true,
-    "version": "4.3.0"
+    "version": "4.4.0rc1"
 }


### PR DESCRIPTION
Bumps `manifest.json` to `4.4.0rc1` and dates the changelog entry.

Tagged `v4.4.0rc1` once merged — a **pre-release**, offered only to installations that opted into beta versions for Scribe.

What it carries, since `v4.3.0`:

- `scribe.query` is bounded — 60 seconds and 20 000 rows, both settable (`query_timeout`, `query_max_rows`), with the rows streamed and counted as they arrive.
- The I/O sensors are no longer polled every 30 seconds; the platform publishes them every 60 seconds, and `stats_io_interval` sets that.