### PR TITLE
docs(readme): the database URL is asked for in the UI first

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -35,7 +35,15 @@ Der Recorder von Home Assistant hält einige Wochen Historie in SQLite und wird 
 
 *Oder von Hand:* `custom_components/scribe` in Ihren `custom_components`-Ordner kopieren. In beiden Fällen Home Assistant neu starten.
 
-**3. Die Datenbank-URL**, in `configuration.yaml`:
+**3. Die Datenbank-URL.** Öffnen Sie **Einstellungen → Geräte & Dienste → Integration hinzufügen**, suchen Sie nach **Scribe** und fügen Sie sie ein:
+
+[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=scribe)
+
+```
+postgresql://scribe:password@192.168.1.10:5432/scribe
+```
+
+*Oder in `configuration.yaml`*, wenn Sie Ihre Konfiguration lieber in Dateien halten:
 
 ```yaml
 scribe:

--- a/README.es.md
+++ b/README.es.md
@@ -35,7 +35,15 @@ El recorder de Home Assistant guarda unas semanas de historial en SQLite y se ra
 
 *O a mano:* copie `custom_components/scribe` en su carpeta `custom_components`. En ambos casos, reinicie Home Assistant.
 
-**3. La URL de la base de datos**, en `configuration.yaml`:
+**3. La URL de la base de datos.** Vaya a **Ajustes → Dispositivos y servicios → Añadir integración**, busque **Scribe** y péguela:
+
+[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=scribe)
+
+```
+postgresql://scribe:password@192.168.1.10:5432/scribe
+```
+
+*O en `configuration.yaml`*, si prefiere mantener su configuración en archivos:
 
 ```yaml
 scribe:

--- a/README.fr.md
+++ b/README.fr.md
@@ -35,7 +35,15 @@ Le recorder de Home Assistant garde quelques semaines d'historique dans SQLite e
 
 *Ou à la main :* copiez `custom_components/scribe` dans votre dossier `custom_components`. Dans les deux cas, redémarrez Home Assistant.
 
-**3. L'URL de la base**, dans `configuration.yaml` :
+**3. L'URL de la base.** Allez dans **Paramètres → Appareils et services → Ajouter une intégration**, cherchez **Scribe**, et collez-la :
+
+[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=scribe)
+
+```
+postgresql://scribe:password@192.168.1.10:5432/scribe
+```
+
+*Ou dans `configuration.yaml`*, si vous préférez garder votre configuration dans des fichiers :
 
 ```yaml
 scribe:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,15 @@ Home Assistant's recorder keeps a few weeks of history in SQLite and slows down 
 
 *Or by hand:* copy `custom_components/scribe` into your `custom_components` folder. Either way, restart Home Assistant.
 
-**3. The database URL**, in `configuration.yaml`:
+**3. The database URL.** Go to **Settings → Devices & services → Add integration**, search for **Scribe**, and paste it:
+
+[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=scribe)
+
+```
+postgresql://scribe:password@192.168.1.10:5432/scribe
+```
+
+*Or in `configuration.yaml`*, if you would rather keep your configuration in files:
 
 ```yaml
 scribe:


### PR DESCRIPTION
Step 3 of the quick start only showed `configuration.yaml`. Someone installing Scribe through HACS and setting it up from the interface never sees that file, and the README left them with nothing to follow.

Step 3 now leads with **Settings → Devices & services → Add integration**, with a My Home Assistant badge that opens the flow directly, and keeps the YAML block below as the alternative for people who keep their configuration in files.

In the four languages.