### PR TITLE
chore: release 4.4.0 as a stable version

### DIFF
--- a/custom_components/scribe/manifest.json
+++ b/custom_components/scribe/manifest.json
@@ -14,5 +14,5 @@
         "asyncpg>=0.28.0"
     ],
     "single_config_entry": true,
-    "version": "4.4.0rc1"
+    "version": "4.4.0"
 }


### PR DESCRIPTION
4.4.0rc1 ran on a live installation for the afternoon: clean start, `init_db` fine, the startup snapshot wrote 1 489 states, no new Repairs issue, and the I/O sensors now write every 60 seconds instead of every 30. No pre-release needed.

`manifest.json` goes from `4.4.0rc1` to `4.4.0`. Tagged `v4.4.0` once merged.