### PR TITLE
docs(readme): say which option is required, at the top of the example

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -118,11 +118,12 @@ GRANT ALL ON SCHEMA public TO scribe;
 
 ### Vollständige Konfiguration (Standardwerte)
 
-#### Vollständige YAML-Konfiguration anzeigen
-
 ```yaml
 scribe:
+  # Die einzige erforderliche Option.
   db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
+
+  # Alles Weitere ist optional. Dies sind die Standardwerte.
   db_ssl: false
   ssl_root_cert: ""      # nur verwendet, wenn db_ssl true ist
   ssl_cert_file: ""
@@ -155,7 +156,7 @@ scribe:
   exclude_attributes: []
   include_events: []
   exclude_events: []
-  # Optional: einzelne Metadaten-Tabellen abschalten (Standard: true)
+  # Die Metadaten-Tabellen, die Scribe aktuell hält.
   enable_table_areas: true
   enable_table_devices: true
   enable_table_integrations: true

--- a/README.es.md
+++ b/README.es.md
@@ -118,11 +118,12 @@ GRANT ALL ON SCHEMA public TO scribe;
 
 ### Configuración completa (valores por defecto)
 
-#### Mostrar la configuración YAML completa
-
 ```yaml
 scribe:
+  # La única opción obligatoria.
   db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
+
+  # Todo lo demás es opcional. Estos son los valores por defecto.
   db_ssl: false
   ssl_root_cert: ""      # solo se usa si db_ssl es true
   ssl_cert_file: ""
@@ -155,7 +156,7 @@ scribe:
   exclude_attributes: []
   include_events: []
   exclude_events: []
-  # Opcional: desactivar tablas de metadatos concretas (por defecto: true)
+  # Las tablas de metadatos que Scribe mantiene al día.
   enable_table_areas: true
   enable_table_devices: true
   enable_table_integrations: true

--- a/README.fr.md
+++ b/README.fr.md
@@ -118,11 +118,12 @@ GRANT ALL ON SCHEMA public TO scribe;
 
 ### Configuration complète (valeurs par défaut)
 
-#### Afficher la configuration YAML complète
-
 ```yaml
 scribe:
+  # La seule option obligatoire.
   db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
+
+  # Tout le reste est facultatif. Voici les valeurs par défaut.
   db_ssl: false
   ssl_root_cert: ""      # utilisé uniquement si db_ssl vaut true
   ssl_cert_file: ""
@@ -155,7 +156,7 @@ scribe:
   exclude_attributes: []
   include_events: []
   exclude_events: []
-  # Optionnel : désactiver certaines tables de métadonnées (défaut : true)
+  # Les tables de métadonnées que Scribe tient à jour.
   enable_table_areas: true
   enable_table_devices: true
   enable_table_integrations: true

--- a/README.md
+++ b/README.md
@@ -115,11 +115,12 @@ GRANT ALL ON SCHEMA public TO scribe;
 
 ### Full Configuration (Default Values)
 
-#### Show Full YAML Configuration
-
 ```yaml
 scribe:
+  # The only required option.
   db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
+
+  # Everything below is optional. These are the defaults.
   db_ssl: false
   ssl_root_cert: ""      # only used when db_ssl is true
   ssl_cert_file: ""
@@ -152,7 +153,7 @@ scribe:
   exclude_attributes: []
   include_events: []
   exclude_events: []
-  # Optional: Disable specific metadata tables (default: true)
+  # The metadata tables Scribe keeps up to date.
   enable_table_areas: true
   enable_table_devices: true
   enable_table_integrations: true


### PR DESCRIPTION
In *Full Configuration (Default Values)*, the only comment about optionality was `# Optional: Disable specific metadata tables`, two thirds of the way down the block. It read as if everything above it were required, when in fact **`db_url` is the only required option**.

The example now says so where it matters:

```yaml
scribe:
  # The only required option.
  db_url: postgresql://scribe:password@192.168.1.10:5432/scribe

  # Everything below is optional. These are the defaults.
  db_ssl: false
```

and the comment on the metadata tables now describes them instead of claiming optionality for them alone.

Also drops `#### Show Full YAML Configuration`, which sat directly under `### Full Configuration (Default Values)` inside a `<details>` already titled *Every option, with its defaults* — three headings for one code block.

In the four languages.