### PR TITLE
docs: audit every README section against the code, and add Dutch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **Dutch**: `README.nl.md` joins the four existing translations, and `nl.json` — which existed but covered barely half of `strings.json`, so a Dutch user read every Repairs issue in English — is now complete and checked by the same tests as the other documented languages.
+
 ## [4.4.0] - 2026-09-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **The migration scripts are tested**: `influx2scribe`, `ltss2scribe`, `recorder2scribe` and their shared preflight write straight into `entities` and `states_raw` with psycopg2, bypassing the writer, and nothing checked they still matched the schema Scribe creates. Twelve tests now run them against a real TimescaleDB — a real SQLite recorder database for the path the documentation never mentioned, a real LTSS table, and stand-in InfluxDB records — covering the backfill itself, that re-running does not duplicate history, that the configured window is a filter, and that a recorder still mid-migration is refused.
 - **Dutch**: `README.nl.md` joins the four existing translations, and `nl.json` — which existed but covered barely half of `strings.json`, so a Dutch user read every Repairs issue in English — is now complete and checked by the same tests as the other documented languages.
 
 ## [4.4.0] - 2026-09-12

--- a/README.de.md
+++ b/README.de.md
@@ -11,7 +11,7 @@ Jeder Zustand und jedes Ereignis, über `asyncpg` — ohne die Event-Loop zu blo
 
 [![Release](https://img.shields.io/github/v/release/jonathan-gtd/scribe?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases/latest) [![Downloads](https://img.shields.io/github/downloads/jonathan-gtd/scribe/total?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases) [![Tests](https://img.shields.io/github/actions/workflow/status/jonathan-gtd/scribe/tests.yaml?branch=master&label=tests)](https://github.com/jonathan-gtd/scribe/actions/workflows/tests.yaml) [![License](https://img.shields.io/github/license/jonathan-gtd/scribe?color=lightgrey)](LICENSE)
 
-[![lang en](https://img.shields.io/badge/lang-en-lightgrey)](README.md) [![lang fr](https://img.shields.io/badge/lang-fr-lightgrey)](README.fr.md) [![lang es](https://img.shields.io/badge/lang-es-lightgrey)](README.es.md) [![lang de](https://img.shields.io/badge/lang-de-41BDF5)](README.de.md)
+[![lang en](https://img.shields.io/badge/lang-en-lightgrey)](README.md) [![lang fr](https://img.shields.io/badge/lang-fr-lightgrey)](README.fr.md) [![lang es](https://img.shields.io/badge/lang-es-lightgrey)](README.es.md) [![lang de](https://img.shields.io/badge/lang-de-41BDF5)](README.de.md) [![lang nl](https://img.shields.io/badge/lang-nl-lightgrey)](README.nl.md)
 
 </div>
 
@@ -478,7 +478,7 @@ data:
 response_variable: purged
 ```
 
-Komprimierte Historie wird ebenfalls gelöscht: TimescaleDB erledigt das, und die Chunks bleiben komprimiert. Für ein gleitendes Fenster, das dauerhaft gilt, nutzen Sie stattdessen die *Aufbewahrung* weiter unten: eine Purge ist einmalig.
+Komprimierte Historie wird ebenfalls gelöscht: TimescaleDB erledigt das, und die Chunks bleiben komprimiert. Für ein gleitendes Fenster, das dauerhaft gilt, nutzen Sie stattdessen die Einstellungen unter *Aufbewahrung* weiter unten: eine Purge ist einmalig.
 
 </details>
 

--- a/README.de.md
+++ b/README.de.md
@@ -25,6 +25,8 @@ Der Recorder von Home Assistant hält einige Wochen Historie in SQLite und wird 
 - 🧩 **Mit Kontext** — Entitäten, Geräte, Bereiche, Benutzer und Integrationen, nicht nur Werte.
 - 🩺 **Es sagt, wenn etwas nicht stimmt**, in Reparaturen statt in einem Log, das niemand liest.
 
+---
+
 ## Installation
 
 **1. Eine TimescaleDB-Datenbank.** Die Erweiterung ist erforderlich — siehe *TimescaleDB einrichten* weiter unten.
@@ -52,11 +54,11 @@ scribe:
 
 Fertig — Zustände werden aufgezeichnet, in Chunks geteilt und komprimiert, mit ihrem Entitäts-, Geräte- und Bereichskontext. Alles Weitere ist optional.
 
+---
+
 <details>
 <summary><b>🧩 Scribe Card — Diagramme auf Ihrem Dashboard</b></summary>
 <br>
-
-[![Scribe Card](https://raw.githubusercontent.com/jonathan-gtd/scribe-card/master/docs/screenshot.png)](https://github.com/jonathan-gtd/scribe-card)
 
 **[Scribe Card](https://github.com/jonathan-gtd/scribe-card)** bringt jede Abfrage Ihrer Historie auf ein Dashboard. Gezeichnet mit Apache ECharts — der Bibliothek, die auch die Verlaufsdiagramme von Home Assistant nutzen — und in einem Formular konfiguriert, in dem Diagrammtyp, Einheit und Achsen aus den Spalten Ihrer Abfrage gewählt werden.
 
@@ -72,8 +74,7 @@ Sie spricht über den Dienst `scribe.query` mit Scribe: **keine zweite Datenbank
 
 Du brauchst eine laufende TimescaleDB-Instanz. Ich empfehle PostgreSQL 17 oder 18.
 
-> [!IMPORTANT]
-> **Die TimescaleDB-Erweiterung ist erforderlich.** Chunking, Komprimierung,
+> **❗ Wichtig** — **Die TimescaleDB-Erweiterung ist erforderlich.** Chunking, Komprimierung,
 > Aufbewahrung und die Größen-Sensoren sind der eigentliche Zweck von Scribe —
 > auf reinem PostgreSQL gibt es davon nichts. Eine neue Installation wird
 > abgelehnt, wenn die Erweiterung fehlt; Scribe aktiviert sie allerdings selbst,
@@ -118,49 +119,63 @@ GRANT ALL ON SCHEMA public TO scribe;
 
 ### Vollständige Konfiguration (Standardwerte)
 
-#### Vollständige YAML-Konfiguration anzeigen
-
 ```yaml
 scribe:
+  # Die einzige erforderliche Option.
   db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
-  db_ssl: false
-  ssl_root_cert: ""      # nur verwendet, wenn db_ssl true ist
-  ssl_cert_file: ""
-  ssl_key_file: ""
-  db_schema: ""      # leer = das Schema der Verbindung
-  chunk_time_interval: "7 days"
-  compress_after: "7 days"
-  retention_states: ""   # leer = unbegrenzt aufbewahren
-  retention_events: ""   # leer = unbegrenzt aufbewahren
-  record_states: true
-  record_events: false
-  batch_size: 500
-  flush_interval: 5
-  max_queue_size: 10000
-  query_timeout: 60
-  query_max_rows: 20000
-  buffer_on_failure: true
-  enable_stats_io: false
-  enable_stats_chunk: false
-  enable_stats_size: false
-  stats_io_interval: 60
-  stats_chunk_interval: 60
-  stats_size_interval: 60
-  include_domains: []
-  include_entities: []
-  include_entity_globs: []
-  exclude_domains: []
+
+  # Alles Weitere ist optional. Dies sind die Standardwerte.
+
+  # Wohin es schreibt
+  db_schema: ""                 # leer = das Schema der Verbindung, normalerweise public
+  db_ssl: false                 # TLS zur Datenbank
+  ssl_root_cert: ""             # CA-Zertifikat; nur gelesen, wenn db_ssl true ist
+  ssl_cert_file: ""             # Client-Zertifikat, für gegenseitiges TLS
+  ssl_key_file: ""              # dessen privater Schlüssel
+
+  # Was es aufzeichnet
+  record_states: true           # Zustandsänderungen
+  record_events: false          # Home-Assistant-Ereignisse (Automationen, Skripte…)
+  include_domains: []           # leer = alle Domains
+  include_entities: []          # leer = alle Entitäten
+  include_entity_globs: []      # z. B. sensor.wetter_*
+  exclude_domains: []           # wird nach den Include-Listen angewendet
   exclude_entities: []
   exclude_entity_globs: []
-  exclude_attributes: []
-  include_events: []
-  exclude_events: []
-  # Optional: einzelne Metadaten-Tabellen abschalten (Standard: true)
+  exclude_attributes: []        # Attribute, die aus der Spalte attributes entfernt werden
+  include_events: []            # leer = alle Ereignistypen
+  exclude_events: []            # wird nach include_events angewendet
+
+  # Wie lange es sie behält
+  chunk_time_interval: "7 days" # Zeitspanne, die ein Chunk abdeckt
+  compress_after: "7 days"      # ältere Chunks werden komprimiert
+  retention_states: ""          # leer = für immer; sonst LÖSCHT es ältere Zustände
+  retention_events: ""          # leer = für immer; sonst LÖSCHT es ältere Ereignisse
+  enable_rollups: false         # stündliche und tägliche Zusammenfassungen numerischer Zustände
+
+  # Wie es schreibt
+  batch_size: 500               # Zeilen im Puffer vor einem Schreibvorgang
+  flush_interval: 5             # Sekunden, bevor ein unvollständiger Stapel geschrieben wird
+  max_queue_size: 10000         # Zeilen im Speicher, bevor neue verworfen werden
+  buffer_on_failure: true       # weiter puffern, solange die Datenbank nicht erreichbar ist
+
+  # Was scribe.query kosten darf
+  query_timeout: 60             # Sekunden, die eine Abfrage laufen darf
+  query_max_rows: 20000         # Zeilen, die sie zurückgeben darf, bevor sie abgelehnt wird
+
+  # Sensoren über Scribe selbst
+  enable_stats_io: false        # Writer-Zähler, aus dem Speicher gelesen
+  enable_stats_chunk: false     # Chunk-Anzahl, eine Abfrage pro Aktualisierung
+  enable_stats_size: false      # Größen auf der Festplatte, eine Abfrage pro Aktualisierung
+  stats_io_interval: 60         # Sekunden zwischen zwei Schreibwerten
+  stats_chunk_interval: 60      # Minuten zwischen zwei Chunk-Abfragen
+  stats_size_interval: 60       # Minuten zwischen zwei Größen-Abfragen
+
+  # Kontext-Tabellen, synchron mit den Registern von Home Assistant
   enable_table_areas: true
   enable_table_devices: true
   enable_table_integrations: true
   enable_table_users: true
-  enable_rollups: false
 ```
 
 </details>
@@ -169,8 +184,6 @@ scribe:
 <summary><b>📋 Parameter-Referenz</b></summary>
 <br>
 
-#### Parameter-Referenz anzeigen
-
 | Parameter | Beschreibung |
 | :--- | :--- |
 | `db_url` | **Erforderlich.** Verbindungszeichenfolge zu deiner TimescaleDB-Datenbank. |
@@ -178,11 +191,11 @@ scribe:
 | `ssl_root_cert` | Pfad zur CA-Datei (z. B. `/ssl/ca.crt`). Ein relativer Pfad wird vom Konfigurationsverzeichnis von Home Assistant aus aufgelöst. |
 | `ssl_cert_file` | Pfad zum Client-Zertifikat, für gegenseitiges TLS. |
 | `ssl_key_file` | Pfad zum privaten Client-Schlüssel, für gegenseitiges TLS. |
-| `db_schema` | PostgreSQL-Schema, in das geschrieben wird. Leer (Standard): das der Verbindung, normalerweise `public`. Siehe [Datenbankschema](#datenbankschema). |
-| `chunk_time_interval` | Welchen Zeitraum ein Chunk der Tabelle abdeckt. Siehe [Speicher-Feinabstimmung](#speicher-feinabstimmung). |
-| `compress_after` | Chunks, die älter sind als dieses Intervall, werden komprimiert. Siehe [Speicher-Feinabstimmung](#speicher-feinabstimmung). |
-| `retention_states` | **Löscht** Zustandsverlauf, der älter ist als dieses Intervall (z. B. `"365 days"`). Leer (Standard) behält alles. Siehe [Aufbewahrung](#aufbewahrung). |
-| `retention_events` | **Löscht** Ereignisverlauf, der älter ist als dieses Intervall. Leer (Standard) behält alles. Siehe [Aufbewahrung](#aufbewahrung). |
+| `db_schema` | PostgreSQL-Schema, in das geschrieben wird. Leer (Standard): das der Verbindung, normalerweise `public`. |
+| `chunk_time_interval` | Welchen Zeitraum ein Chunk der Tabelle abdeckt. Siehe *Speicher-Feinabstimmung* weiter unten. |
+| `compress_after` | Chunks, die älter sind als dieses Intervall, werden komprimiert. Siehe *Speicher-Feinabstimmung* weiter unten. |
+| `retention_states` | **Löscht** Zustandsverlauf, der älter ist als dieses Intervall (z. B. `"365 days"`). Leer (Standard) behält alles. Siehe *Aufbewahrung* weiter unten. |
+| `retention_events` | **Löscht** Ereignisverlauf, der älter ist als dieses Intervall. Leer (Standard) behält alles. Siehe *Aufbewahrung* weiter unten. |
 | `record_states` | Ob Zustandsänderungen aufgezeichnet werden. |
 | `record_events` | Ob Ereignisse aufgezeichnet werden. |
 | `batch_size` | Anzahl der Einträge, die gepuffert werden, bevor in die Datenbank geschrieben wird. |
@@ -223,7 +236,7 @@ sich wie jede andere verhält und abfragen lässt, physisch aber in **Chunks**
 zerlegt ist, von denen jeder einen Zeitabschnitt abdeckt. Fast alles, was
 Plattenplatz und Abfragegeschwindigkeit betrifft, folgt aus dieser Aufteilung:
 Eine Abfrage über die letzte Woche liest nur die Chunks, die sie überlappen, die
-Komprimierung arbeitet Chunk für Chunk, und die [Aufbewahrung](#aufbewahrung)
+Komprimierung arbeitet Chunk für Chunk, und die *Aufbewahrung* weiter unten
 löscht ganze Chunks statt einzelner Zeilen.
 
 Gesteuert wird das von zwei Einstellungen, in YAML wie in der Oberfläche unter
@@ -313,8 +326,7 @@ scribe:
 Beides gibt es auch in der Oberfläche unter
 **Konfigurieren → Erweitert (TimescaleDB & SSL)**.
 
-> [!WARNING]
-> Die Aufbewahrung **löscht Daten endgültig**. Es gibt kein Rückgängig und
+> **⚠️ Achtung** — Die Aufbewahrung **löscht Daten endgültig**. Es gibt kein Rückgängig und
 > keinen Papierkorb: Sobald ein Chunk aus dem Fenster fällt, wird er gelöscht,
 > und nur eine Sicherung bringt ihn zurück. Zustände und Ereignisse werden
 > getrennt konfiguriert, sodass du lärmende Ereignisse verfallen lassen und den
@@ -364,7 +376,7 @@ scribe:
   enable_rollups: true
 ```
 
-Das ergänzt zwei Sichten:
+Auch in der Oberfläche unter **Konfigurieren → Metadaten-Tabellen**. Das ergänzt zwei Sichten:
 
 | Sicht | Eine Zeile je | Spalten |
 | --- | --- | --- |
@@ -379,20 +391,17 @@ WHERE entity_id = 'sensor.aussentemperatur'
 ORDER BY bucket;
 ```
 
-Zusammengefasst werden nur numerische Zustände — der Mittelwert von `on` und `off` bedeutet nichts — und `samples` sagt, für wie viele Zustände eine Zeile steht.
+Zusammengefasst werden nur numerische Zustände — der Mittelwert von `on` und `off` bedeutet nichts — deshalb bleiben `value_avg`, `value_min` und `value_max` für alle anderen leer, während `samples` jeden Zustand im Bucket zählt.
 
-**Es sind abgeleitete Daten.** Nichts, was Sie vermissen würden, wird doppelt gehalten: Ausschalten löscht beide Sichten, Wiedereinschalten baut sie aus der Historie neu auf, und Ihre Zustände bleiben in beiden Fällen unberührt. TimescaleDB hält sie selbst aktuell; Scribe legt sie nur an.
+**Es sind abgeleitete Daten.** Nichts, was Sie vermissen würden, wird doppelt gehalten: Ausschalten löscht beide Sichten, Wiedereinschalten baut sie aus der Historie neu auf, und Ihre Zustände bleiben in beiden Fällen unberührt. TimescaleDB aktualisiert sie selbst — die stündliche alle 30 Minuten, die tägliche jede Stunde — und jeder Lauf schaut weit genug zurück (3 Tage, 30 Tage), dass auch ein spät geschriebener Stapel darin landet. Scribe legt sie nur an.
 
 </details>
 
 <details>
-<summary><b>🗃️ Datenbankschema — Tabellen, Sichten und wie man sie abfragt</b></summary>
+<summary><b>🗃️ In ein bestimmtes PostgreSQL-Schema schreiben</b></summary>
 <br>
 
-Standardmäßig schreibt Scribe in das Schema, auf das die Verbindung ohnehin
-zeigt — normalerweise `public`. Wird `db_schema` gesetzt, legt Scribe dieses
-Schema an und packt alles hinein: seine Tabellen, seine Views, seine Hypertables
-und seine Richtlinien.
+Standardmäßig schreibt Scribe in das Schema, auf das Ihre Verbindung ohnehin zeigt — normalerweise `public`. Setzen Sie `db_schema`, und es legt dieses Schema an und packt alles hinein: Tabellen, Sichten, Hypertables und Richtlinien.
 
 ```yaml
 scribe:
@@ -400,48 +409,17 @@ scribe:
   db_schema: scribe
 ```
 
-Die Option steht auch in der Oberfläche unter **Konfigurieren → Erweitert
-(TimescaleDB & SSL)**.
+Auch in der Oberfläche unter **Konfigurieren → Erweitert (TimescaleDB & SSL)**.
 
-Das ist die richtige Wahl, wenn Scribe sich eine Datenbank mit etwas anderem
-teilt: eigenen umgewandelten Kopien der Historie, Tabellen einer anderen
-Integration oder einem zweiten Home Assistant, das auf denselben Server
-schreibt. Jedes Schema ist eigenständig — eigene Tabellen, eigene Hypertables,
-eigene Aufbewahrungs- und Komprimierungsrichtlinien — und nichts, was Scribe im
-einen tut, erreicht das andere.
+Das wollen Sie, wenn Scribe sich eine Datenbank mit etwas anderem teilt: den Tabellen einer anderen Integration, Ihren eigenen Kopien der Historie oder einem zweiten Home Assistant auf demselben Server. Schemata sind unabhängig — eigene Tabellen, Hypertables, Aufbewahrung und Kompression — und nichts, was Scribe im einen tut, erreicht das andere.
 
-Wissenswertes:
+- **Nur neue Daten landen dort.** `db_schema` zu setzen verschiebt bereits aufgezeichnete Historie nicht. Verschieben Sie sie vor dem Neustart selbst (`ALTER TABLE public.states_raw SET SCHEMA scribe;`) oder fragen Sie das alte Schema direkt ab.
+- **Scribe legt das Schema an, wenn es darf** — dafür braucht der Benutzer `CREATE` auf der Datenbank. Ein von Hand angelegtes Schema geht ebenso, mit `USAGE` und `CREATE` darauf.
+- **Ein unerreichbares Schema stoppt die Aufzeichnung.** PostgreSQL fällt auf den nächsten Eintrag des Search Path zurück, statt zu scheitern; ein Tippfehler würde also `public` füllen, während die Oberfläche etwas anderes zeigt. Scribe prüft, wo es gelandet ist, und schreibt lieber nichts als am falschen Ort — mit einem Eintrag in Reparaturen, der sagt, was zu gewähren ist.
+- **Ihre Abfragen ändern sich nicht.** Scribe stellt das Schema an den Anfang des `search_path` der Verbindung, `SELECT * FROM states` funktioniert über `scribe.query` weiter. Aus Grafana oder psql qualifizieren Sie den Namen (`scribe.states`) oder setzen Ihren eigenen `search_path`. `public` bleibt auf dem Pfad — dort liegen die TimescaleDB-Funktionen.
+- Zulässig sind einfache Bezeichner: Buchstaben, Ziffern und Unterstriche, nicht mit einer Ziffer beginnend. Leer behält das Schema der Verbindung, auch eines, das Sie selbst mit `?options=-csearch_path%3Dmeinschema` in der URL gesetzt haben.
 
-- **Nur neue Daten landen dort.** `db_schema` verschiebt keine bereits
-  aufgezeichnete Historie: Scribe legt im neuen Schema einen leeren Satz Tabellen
-  an und schreibt ab da dorthin. Um die alte Historie zu behalten, verschieben
-  Sie sie selbst (`ALTER TABLE public.states_raw SET SCHEMA scribe;`) vor dem
-  Neustart, oder fragen Sie das alte Schema direkt ab.
-- **Scribe legt das Schema an, wenn es darf.** Dafür braucht der
-  Datenbankbenutzer `CREATE` auf der Datenbank. Ein von jemand anderem angelegtes
-  Schema funktioniert genauso, solange der Benutzer `USAGE` und `CREATE` darauf
-  hat:
-  ```sql
-  CREATE SCHEMA IF NOT EXISTS scribe;
-  GRANT USAGE, CREATE ON SCHEMA scribe TO scribe;
-  ```
-- **Ein nicht erreichbares Schema stoppt die Aufzeichnung.** PostgreSQL scheitert
-  nicht an einem fehlenden Schema, sondern fällt still auf den nächsten Eintrag
-  im Search Path zurück — ein Tippfehler oder ein fehlendes Recht würde also
-  `public` füllen, während die Oberfläche etwas anderes anzeigt. Scribe prüft,
-  wo es tatsächlich gelandet ist, und zeichnet lieber gar nichts auf als das
-  Falsche, mit einem Eintrag unter Reparaturen, der die nötigen Rechte erklärt.
-- **Ihre Abfragen ändern sich nicht.** Scribe setzt das Schema an den Anfang des
-  `search_path` der Verbindung, `SELECT * FROM states` funktioniert also über den
-  Dienst `scribe.query` weiterhin. Von außerhalb — Grafana, psql, ein Dashboard —
-  qualifizieren Sie den Namen (`scribe.states`) oder setzen Ihren eigenen
-  `search_path`.
-- **`public` bleibt im Pfad.** Dort installiert die TimescaleDB-Erweiterung
-  `create_hypertable()` und Verwandte, die Scribe aufrufen muss.
-- Zulässig sind einfache Bezeichner: Buchstaben, Ziffern und Unterstriche, nicht
-  mit einer Ziffer beginnend. Leer lassen, um weiter das Schema der Verbindung zu
-  nutzen — auch eines, das Sie selbst mit `?options=-csearch_path%3Dmeinschema`
-  in der URL gesetzt haben; Scribe folgt ihm und überschreibt es nicht.
+**Die Tabellen selbst** — jede Spalte, ihre Beziehungen und Abfragerezepte für Grafana und `scribe.query` — sind in [`docs/data-structure.md`](docs/data-structure.md) dokumentiert.
 
 </details>
 
@@ -500,7 +478,7 @@ data:
 response_variable: purged
 ```
 
-Komprimierte Historie wird ebenfalls gelöscht: TimescaleDB erledigt das, und die Chunks bleiben komprimiert. Für ein gleitendes Fenster, das dauerhaft gilt, nutzen Sie stattdessen die [Aufbewahrung](#aufbewahrung): eine Purge ist einmalig.
+Komprimierte Historie wird ebenfalls gelöscht: TimescaleDB erledigt das, und die Chunks bleiben komprimiert. Für ein gleitendes Fenster, das dauerhaft gilt, nutzen Sie stattdessen die *Aufbewahrung* weiter unten: eine Purge ist einmalig.
 
 </details>
 
@@ -512,8 +490,6 @@ Aktiviere die Sensoren, indem du ihre Optionen in der Konfiguration setzt.
 
 ### Schreibstatistiken (`enable_stats_io: true`)
 
-#### Schreib-Sensoren anzeigen
-
 Echtzeitwerte aus dem Writer (ohne Datenbankabfragen).
 
 | Sensor | Beschreibung |
@@ -521,14 +497,11 @@ Echtzeitwerte aus dem Writer (ohne Datenbankabfragen).
 | <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_states_written` | Gesamtzahl der in die Datenbank geschriebenen Zustandsänderungen. |
 | <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_events_written` | Gesamtzahl der in die Datenbank geschriebenen Ereignisse. |
 | <img src="https://api.iconify.design/mdi:buffer.svg?color=%232196F3" width="15" /> `sensor.scribe_buffer_size` | Aktuelle Anzahl der Einträge im Speicherpuffer. |
-| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_write_duration` | Dauer (in ms) des letzten Schreibvorgangs. |
+| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_last_write_duration` | Dauer (in ms) des letzten Schreibvorgangs. |
 | <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_states_rate` | Rate der geschriebenen Zustände (pro Minute). |
 | <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_events_rate` | Rate der geschriebenen Ereignisse (pro Minute). |
 
-
 ### Chunk-Statistiken (`enable_stats_chunk: true`)
-
-#### Chunk-Sensoren anzeigen
 
 Chunk-Anzahl (alle `stats_chunk_interval` Minuten aktualisiert).
 
@@ -541,10 +514,7 @@ Chunk-Anzahl (alle `stats_chunk_interval` Minuten aktualisiert).
 | <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_chunks` | Anzahl der komprimierten Ereignis-Chunks. |
 | <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_chunks` | Anzahl der unkomprimierten Ereignis-Chunks. |
 
-
 ### Größenstatistiken (`enable_stats_size: true`)
-
-#### Größen-Sensoren anzeigen
 
 Belegter Speicher in Bytes (alle `stats_size_interval` Minuten aktualisiert).
 
@@ -618,87 +588,24 @@ Neuinstallationen und jede von 3.x angelegte Datenbank sind nicht betroffen.
 
 ### Daten aus anderen Quellen übernehmen
 
-Scribe bringt Skripte mit, um Daten aus verschiedenen Quellen zu übernehmen.
+In `migration/` liegen drei Skripte, die Historie von anderswo nach Scribe kopieren. Sie werden einmalig von Hand ausgeführt, auf einem Rechner, der beide Datenbanken erreicht — und Scribe muss mindestens einmal gestartet sein, damit seine Tabellen existieren.
 
-### Migration aus InfluxDB
+```bash
+cd migration
+pip install psycopg2-binary python-dotenv   # für InfluxDB zusätzlich influxdb-client
+cp .env.example .env && nano .env
+python3 <script>.py
+```
 
-#### InfluxDB-Migrationsanleitung anzeigen
+| Quelle | Skript | Auszufüllen |
+| --- | --- | --- |
+| InfluxDB | `influx2scribe.py` | `INFLUX_*` |
+| LTSS | `ltss2scribe.py` | `LTSS_*` |
+| Home-Assistant-Recorder | `recorder2scribe.py` | `RECORDER_*`, mit `RECORDER_TYPE` auf `postgres` oder `sqlite` (SQLite braucht nur `RECORDER_DB_PATH`) |
 
-1. Wechsle in das Verzeichnis `migration`:
-   ```bash
-   cd migration
-   ```
+Jeder Lauf braucht außerdem `SCRIBE_*` — das Ziel — und die Migrationseinstellungen: `MIGRATION_START_TIME`, `MIGRATION_END_TIME`, `CHUNK_SIZE` (Stunden pro Stapel) und `PURGE_DESTINATION`, das **die Historie des Ziels vor dem Import löscht**. Lassen Sie es auf `False`, sofern Sie es nicht ausdrücklich wollen.
 
-2. Installiere die Abhängigkeiten:
-   ```bash
-   pip install influxdb-client psycopg2-binary python-dotenv
-   ```
-
-3. Konfiguriere die Migration:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Trage [InfluxDB Configuration], [Scribe Configuration] und [Migration Settings] ein
-   ```
-
-4. Starte die Migration:
-   ```bash
-   python3 influx2scribe.py
-   ```
-
-
-### Migration aus LTSS
-
-#### LTSS-Migrationsanleitung anzeigen
-
-1. Wechsle in das Verzeichnis `migration`:
-   ```bash
-   cd migration
-   ```
-
-2. Installiere die Abhängigkeiten:
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Konfiguriere die Migration:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Trage [LTSS Configuration], [Scribe Configuration] und [Migration Settings] ein
-   ```
-
-4. Starte die Migration:
-   ```bash
-   python3 ltss2scribe.py
-   ```
-
-
-### Migration aus dem Recorder
-
-#### Recorder-Migrationsanleitung anzeigen
-
-1. Wechsle in das Verzeichnis `migration`:
-   ```bash
-   cd migration
-   ```
-
-2. Installiere die Abhängigkeiten:
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Konfiguriere die Migration:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Trage [Recorder Configuration], [Scribe Configuration] und [Migration Settings] ein
-   ```
-
-4. Starte die Migration:
-   ```bash
-   python3 recorder2scribe.py
-   ```
+Jedes Skript prüft das Zielschema, bevor es irgendetwas schreibt, und hält mit einer Erklärung an statt mit einer Mauer aus Fehlern Zeile für Zeile, falls Scribe es nie initialisiert hat.
 
 </details>
 
@@ -775,17 +682,7 @@ Loops), die für Scribes Leistung bei großen Datenmengen entscheidend sind.
 
 </details>
 
-<details>
-<summary><b>🔗 Verwandte Projekte</b></summary>
-<br>
-
-Diese Projekte harmonieren gut mit Scribe:
-
-- [Scribe Card](https://github.com/jonathan-gtd/scribe-card): die begleitende Karte — jede Abfrage Ihrer Historie, auf einem Dashboard.
-- [timescale_database_reader](https://github.com/remmob/timescale_database_reader): eine benutzerdefinierte Komponente, die Daten aus TimescaleDB zurück in Home-Assistant-Sensoren liest.
-- [timescale-plotly-card](https://github.com/remmob/timescale-plotly-card): eine hochgradig anpassbare Karte auf Plotly-Basis, die TimescaleDB direkt abfragen kann.
-
-</details>
+---
 
 ## Lizenz
 

--- a/README.es.md
+++ b/README.es.md
@@ -25,6 +25,8 @@ El recorder de Home Assistant guarda unas semanas de historial en SQLite y se ra
 - 🧩 **Con su contexto** — entidades, dispositivos, áreas, usuarios e integraciones, no solo valores.
 - 🩺 **Avisa cuando algo va mal**, en Reparaciones en lugar de en un registro que nadie lee.
 
+---
+
 ## Instalación
 
 **1. Una base de datos TimescaleDB.** La extensión es obligatoria — vea *Instalar TimescaleDB* más abajo.
@@ -52,11 +54,11 @@ scribe:
 
 Listo — los estados se registran, se dividen en chunks y se comprimen, con su contexto de entidad, dispositivo y área. Todo lo que sigue es opcional.
 
+---
+
 <details>
 <summary><b>🧩 Scribe Card — gráficos en su panel</b></summary>
 <br>
-
-[![Scribe Card](https://raw.githubusercontent.com/jonathan-gtd/scribe-card/master/docs/screenshot.png)](https://github.com/jonathan-gtd/scribe-card)
 
 **[Scribe Card](https://github.com/jonathan-gtd/scribe-card)** muestra cualquier consulta de su historial en un panel. Dibujada con Apache ECharts —la biblioteca que usan los propios gráficos de historial de Home Assistant— y configurada en un formulario, donde el tipo de gráfico, la unidad y los ejes se eligen entre las columnas que devuelve su consulta.
 
@@ -72,8 +74,7 @@ Usa el servicio `scribe.query`, así que **no hay una segunda conexión a la bas
 
 Necesitas una instancia de TimescaleDB en funcionamiento. Recomiendo PostgreSQL 17 o 18.
 
-> [!IMPORTANT]
-> **La extensión TimescaleDB es obligatoria.** La división en chunks, la
+> **❗ Importante** — **La extensión TimescaleDB es obligatoria.** La división en chunks, la
 > compresión, la retención y los sensores de tamaño son la razón de ser de
 > Scribe, y ninguno existe en PostgreSQL a secas. Una instalación nueva se
 > rechaza si falta la extensión, aunque Scribe la activa por ti cuando el
@@ -118,49 +119,63 @@ GRANT ALL ON SCHEMA public TO scribe;
 
 ### Configuración completa (valores por defecto)
 
-#### Mostrar la configuración YAML completa
-
 ```yaml
 scribe:
+  # La única opción obligatoria.
   db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
-  db_ssl: false
-  ssl_root_cert: ""      # solo se usa si db_ssl es true
-  ssl_cert_file: ""
-  ssl_key_file: ""
-  db_schema: ""      # vacío = el esquema de la conexión
-  chunk_time_interval: "7 days"
-  compress_after: "7 days"
-  retention_states: ""   # vacío = conservar para siempre
-  retention_events: ""   # vacío = conservar para siempre
-  record_states: true
-  record_events: false
-  batch_size: 500
-  flush_interval: 5
-  max_queue_size: 10000
-  query_timeout: 60
-  query_max_rows: 20000
-  buffer_on_failure: true
-  enable_stats_io: false
-  enable_stats_chunk: false
-  enable_stats_size: false
-  stats_io_interval: 60
-  stats_chunk_interval: 60
-  stats_size_interval: 60
-  include_domains: []
-  include_entities: []
-  include_entity_globs: []
-  exclude_domains: []
+
+  # Todo lo demás es opcional. Estos son los valores por defecto.
+
+  # Dónde registra
+  db_schema: ""                 # vacío = el esquema de la conexión, normalmente public
+  db_ssl: false                 # TLS hacia la base de datos
+  ssl_root_cert: ""             # certificado CA; solo se lee si db_ssl es true
+  ssl_cert_file: ""             # certificado de cliente, para TLS mutuo
+  ssl_key_file: ""              # su clave privada
+
+  # Qué registra
+  record_states: true           # los cambios de estado
+  record_events: false          # los eventos de Home Assistant (automatizaciones, scripts…)
+  include_domains: []           # vacío = todos los dominios
+  include_entities: []          # vacío = todas las entidades
+  include_entity_globs: []      # p. ej. sensor.tiempo_*
+  exclude_domains: []           # se aplica después de las listas de inclusión
   exclude_entities: []
   exclude_entity_globs: []
-  exclude_attributes: []
-  include_events: []
-  exclude_events: []
-  # Opcional: desactivar tablas de metadatos concretas (por defecto: true)
+  exclude_attributes: []        # atributos que se quitan de la columna attributes
+  include_events: []            # vacío = todos los tipos de evento
+  exclude_events: []            # se aplica después de include_events
+
+  # Cuánto tiempo lo guarda
+  chunk_time_interval: "7 days" # tiempo que abarca un chunk
+  compress_after: "7 days"      # los chunks más antiguos se comprimen
+  retention_states: ""          # vacío = para siempre; si no, BORRA los estados anteriores
+  retention_events: ""          # vacío = para siempre; si no, BORRA los eventos anteriores
+  enable_rollups: false         # resúmenes por hora y por día de los estados numéricos
+
+  # Cómo escribe
+  batch_size: 500               # filas en el búfer antes de una escritura
+  flush_interval: 5             # segundos antes de escribir un lote incompleto
+  max_queue_size: 10000         # filas en memoria antes de descartar las nuevas
+  buffer_on_failure: true       # seguir almacenando mientras la base no responda
+
+  # Lo que scribe.query puede costar
+  query_timeout: 60             # segundos que puede durar una consulta
+  query_max_rows: 20000         # filas que puede devolver antes de ser rechazada
+
+  # Sensores sobre el propio Scribe
+  enable_stats_io: false        # contadores del writer, leídos en memoria
+  enable_stats_chunk: false     # número de chunks, una consulta por actualización
+  enable_stats_size: false      # tamaños en disco, una consulta por actualización
+  stats_io_interval: 60         # segundos entre dos valores de escritura
+  stats_chunk_interval: 60      # minutos entre dos consultas de chunks
+  stats_size_interval: 60       # minutos entre dos consultas de tamaño
+
+  # Tablas de contexto, sincronizadas con los registros de Home Assistant
   enable_table_areas: true
   enable_table_devices: true
   enable_table_integrations: true
   enable_table_users: true
-  enable_rollups: false
 ```
 
 </details>
@@ -169,8 +184,6 @@ scribe:
 <summary><b>📋 Referencia de parámetros</b></summary>
 <br>
 
-#### Mostrar la referencia de parámetros
-
 | Parámetro | Descripción |
 | :--- | :--- |
 | `db_url` | **Obligatorio.** Cadena de conexión a tu base de datos TimescaleDB. |
@@ -178,11 +191,11 @@ scribe:
 | `ssl_root_cert` | Ruta al archivo de la CA (p. ej. `/ssl/ca.crt`). Una ruta relativa se resuelve desde el directorio de configuración de Home Assistant. |
 | `ssl_cert_file` | Ruta al certificado de cliente, para TLS mutuo. |
 | `ssl_key_file` | Ruta a la clave privada del cliente, para TLS mutuo. |
-| `db_schema` | Esquema PostgreSQL en el que registrar. Vacío (predeterminado): el de la conexión, normalmente `public`. Consulte [Esquema de la base de datos](#esquema-de-la-base-de-datos). |
-| `chunk_time_interval` | Cuánto tiempo abarca cada chunk de la tabla. Ver [Ajuste del almacenamiento](#ajuste-del-almacenamiento). |
-| `compress_after` | Los chunks más antiguos que este intervalo se comprimen. Ver [Ajuste del almacenamiento](#ajuste-del-almacenamiento). |
-| `retention_states` | **Elimina** el historial de estados más antiguo que este intervalo (p. ej. `"365 days"`). Vacío (por defecto) conserva todo. Ver [Retención](#retención). |
-| `retention_events` | **Elimina** el historial de eventos más antiguo que este intervalo. Vacío (por defecto) conserva todo. Ver [Retención](#retención). |
+| `db_schema` | Esquema PostgreSQL en el que registrar. Vacío (predeterminado): el de la conexión, normalmente `public`. |
+| `chunk_time_interval` | Cuánto tiempo abarca cada chunk de la tabla. Ver *Ajuste del almacenamiento* más abajo. |
+| `compress_after` | Los chunks más antiguos que este intervalo se comprimen. Ver *Ajuste del almacenamiento* más abajo. |
+| `retention_states` | **Elimina** el historial de estados más antiguo que este intervalo (p. ej. `"365 days"`). Vacío (por defecto) conserva todo. Ver *Retención* más abajo. |
+| `retention_events` | **Elimina** el historial de eventos más antiguo que este intervalo. Vacío (por defecto) conserva todo. Ver *Retención* más abajo. |
 | `record_states` | Registrar o no los cambios de estado. |
 | `record_events` | Registrar o no los eventos. |
 | `batch_size` | Número de elementos que se acumulan antes de escribir en la base de datos. |
@@ -223,7 +236,7 @@ usa y se consulta como cualquier otra, pero que está físicamente dividida en
 **chunks**, cada uno cubriendo un tramo de tiempo. Casi todo lo relativo al
 espacio en disco y a la velocidad de las consultas viene de esa división: una
 consulta sobre la semana pasada solo lee los chunks que la solapan, la
-compresión trabaja chunk a chunk, y la [retención](#retención) elimina chunks
+compresión trabaja chunk a chunk, y la *retención* más abajo elimina chunks
 enteros en lugar de filas sueltas.
 
 Lo controlan dos ajustes, tanto en YAML como en la interfaz, en
@@ -309,8 +322,7 @@ scribe:
 
 Ambos están también en la interfaz, en **Configurar → Avanzado (TimescaleDB y SSL)**.
 
-> [!WARNING]
-> La retención **elimina datos de forma permanente**. No hay deshacer ni
+> **⚠️ Atención** — La retención **elimina datos de forma permanente**. No hay deshacer ni
 > papelera: en cuanto un chunk queda fuera de la ventana se elimina, y solo una
 > copia de seguridad puede recuperarlo. Estados y eventos se configuran por
 > separado, así puedes caducar eventos ruidosos conservando el historial de
@@ -360,7 +372,7 @@ scribe:
   enable_rollups: true
 ```
 
-Esto añade dos vistas:
+También está en la interfaz, en **Configurar → Tablas de metadatos**. Esto añade dos vistas:
 
 | Vista | Una fila por | Columnas |
 | --- | --- | --- |
@@ -375,19 +387,17 @@ WHERE entity_id = 'sensor.temperatura_exterior'
 ORDER BY bucket;
 ```
 
-Solo se resumen los estados numéricos —la media de `on` y `off` no significa nada— y `samples` indica cuántos estados representa cada fila.
+Solo se resumen los estados numéricos —la media de `on` y `off` no significa nada— así que `value_avg`, `value_min` y `value_max` quedan vacíos para el resto, mientras que `samples` cuenta todos los estados del bucket.
 
-**Son datos derivados.** No se duplica nada que vaya a echar de menos: desactivar la opción elimina ambas vistas, reactivarla las reconstruye a partir del historial, y sus estados no se tocan en ningún caso. TimescaleDB las mantiene por sí mismo; Scribe solo las crea.
+**Son datos derivados.** No se duplica nada que vaya a echar de menos: desactivar la opción elimina ambas vistas, reactivarla las reconstruye a partir del historial, y sus estados no se tocan en ningún caso. TimescaleDB las refresca por sí mismo —la de por hora cada 30 minutos, la diaria cada hora— y cada pasada mira lo bastante atrás (3 días, 30 días) como para que un lote escrito tarde acabe en ellas. Scribe solo las crea.
 
 </details>
 
 <details>
-<summary><b>🗃️ Esquema de la base — tablas, vistas y cómo consultarlas</b></summary>
+<summary><b>🗃️ Registrar en un esquema de PostgreSQL concreto</b></summary>
 <br>
 
-De forma predeterminada, Scribe registra en el esquema al que ya apunta su
-conexión — normalmente `public`. Indique `db_schema` y creará ese esquema y
-pondrá todo en él: sus tablas, sus vistas, sus hipertablas y sus políticas.
+Por defecto Scribe registra en el esquema al que ya apunta su conexión —normalmente `public`—. Indique `db_schema` y creará ese esquema y pondrá todo en él: sus tablas, sus vistas, sus hypertables y sus políticas.
 
 ```yaml
 scribe:
@@ -397,44 +407,15 @@ scribe:
 
 También está en la interfaz, en **Configurar → Avanzado (TimescaleDB y SSL)**.
 
-Esto es lo que necesita cuando Scribe comparte base de datos con otra cosa: sus
-propias copias transformadas del historial, las tablas de otra integración, o un
-segundo Home Assistant registrando en el mismo servidor. Cada esquema es
-independiente — tablas, hipertablas y políticas de retención y compresión
-separadas — y nada de lo que Scribe hace en uno alcanza al otro.
+Es lo que quiere cuando Scribe comparte una base con otra cosa: las tablas de otra integración, sus propias copias del historial, o un segundo Home Assistant registrando en el mismo servidor. Los esquemas son independientes —tablas, hypertables, retención y compresión separadas— y nada de lo que Scribe hace en uno alcanza al otro.
 
-Conviene saber:
+- **Solo van allí los datos nuevos.** Indicar `db_schema` no mueve el historial ya registrado. Muévalo usted antes de reiniciar (`ALTER TABLE public.states_raw SET SCHEMA scribe;`), o consulte el esquema antiguo directamente.
+- **Scribe crea el esquema si puede**, lo que requiere `CREATE` sobre la base. Uno creado a mano también sirve, con `USAGE` y `CREATE` sobre él.
+- **Un esquema inalcanzable detiene el registro.** PostgreSQL pasa a la siguiente entrada del search path en lugar de fallar, así que una errata llenaría `public` mientras la interfaz muestra otra cosa. Scribe comprueba dónde ha aterrizado y no registra nada antes que registrar en el sitio equivocado, con un problema en Reparaciones que dice qué conceder.
+- **Sus consultas no cambian.** Scribe pone el esquema primero en el `search_path` de la conexión, así que `SELECT * FROM states` sigue funcionando a través de `scribe.query`. Desde Grafana o psql, califique el nombre (`scribe.states`) o defina su propio `search_path`. `public` sigue en la ruta: ahí viven las funciones de TimescaleDB.
+- Los valores aceptados son identificadores simples: letras, dígitos y guiones bajos, sin empezar por un dígito. Vacío mantiene el esquema de la conexión, incluido uno que haya fijado usted con `?options=-csearch_path%3Dmiesquema` en la URL.
 
-- **Solo van allí los datos nuevos.** Indicar `db_schema` no mueve el historial
-  ya registrado: Scribe crea un conjunto de tablas vacío en el nuevo esquema y
-  empieza a escribir en él. Para conservar el historial anterior, muévalo usted
-  mismo (`ALTER TABLE public.states_raw SET SCHEMA scribe;`) antes de reiniciar,
-  o consulte directamente el esquema antiguo.
-- **Scribe crea el esquema si puede.** El usuario de la base de datos necesita
-  `CREATE` sobre ella. Un esquema creado por otra persona sirve igual, siempre
-  que el usuario tenga `USAGE` y `CREATE` sobre él:
-  ```sql
-  CREATE SCHEMA IF NOT EXISTS scribe;
-  GRANT USAGE, CREATE ON SCHEMA scribe TO scribe;
-  ```
-- **Un esquema inaccesible detiene el registro.** PostgreSQL no falla ante un
-  esquema ausente: pasa en silencio a la siguiente entrada del search path, de
-  modo que una errata o un permiso faltante llenarían `public` mientras la
-  interfaz muestra otra cosa. Scribe comprueba dónde ha acabado realmente y no
-  registra nada en lugar de registrar en el sitio equivocado, con un problema en
-  Reparaciones que explica qué permisos conceder.
-- **Sus consultas no cambian.** Scribe pone el esquema primero en el
-  `search_path` de la conexión, así que `SELECT * FROM states` sigue funcionando
-  con el servicio `scribe.query`. Desde cualquier otro sitio — Grafana, psql, un
-  panel — cualifique el nombre (`scribe.states`) o defina su propio
-  `search_path`.
-- **`public` permanece en la ruta.** Ahí es donde la extensión TimescaleDB
-  instala `create_hypertable()` y compañía, que Scribe necesita llamar.
-- Los valores aceptados son identificadores simples: letras, dígitos y guiones
-  bajos, sin empezar por un dígito. Déjelo vacío para seguir usando el esquema de
-  la conexión — incluido el que usted mismo haya fijado con
-  `?options=-csearch_path%3Dmiesquema` en la URL, que Scribe respeta y no
-  sustituye.
+**Las tablas en sí** —cada columna, cómo se relacionan y recetas de consulta para Grafana y `scribe.query`— están documentadas en [`docs/data-structure.md`](docs/data-structure.md).
 
 </details>
 
@@ -493,7 +474,7 @@ data:
 response_variable: purged
 ```
 
-El historial comprimido también se purga: TimescaleDB se encarga y los chunks siguen comprimidos. Para una ventana deslizante que se aplique continuamente, use los ajustes de [retención](#retención): una purga es puntual.
+El historial comprimido también se purga: TimescaleDB se encarga y los chunks siguen comprimidos. Para una ventana deslizante que se aplique continuamente, use los ajustes de *retención* más abajo: una purga es puntual.
 
 </details>
 
@@ -505,8 +486,6 @@ Activa los sensores estableciendo sus opciones en la configuración.
 
 ### Estadísticas de escritura (`enable_stats_io: true`)
 
-#### Mostrar los sensores de escritura
-
 Métricas en tiempo real del escritor (sin consultas a la base de datos).
 
 | Sensor | Descripción |
@@ -514,14 +493,11 @@ Métricas en tiempo real del escritor (sin consultas a la base de datos).
 | <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_states_written` | Número total de cambios de estado escritos en la base. |
 | <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_events_written` | Número total de eventos escritos en la base. |
 | <img src="https://api.iconify.design/mdi:buffer.svg?color=%232196F3" width="15" /> `sensor.scribe_buffer_size` | Elementos que esperan actualmente en el búfer de memoria. |
-| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_write_duration` | Tiempo (en ms) de la última escritura en la base. |
+| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_last_write_duration` | Tiempo (en ms) de la última escritura en la base. |
 | <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_states_rate` | Ritmo de estados escritos (por minuto). |
 | <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_events_rate` | Ritmo de eventos escritos (por minuto). |
 
-
 ### Estadísticas de chunks (`enable_stats_chunk: true`)
-
-#### Mostrar los sensores de chunks
 
 Número de chunks (actualizado cada `stats_chunk_interval` minutos).
 
@@ -534,10 +510,7 @@ Número de chunks (actualizado cada `stats_chunk_interval` minutos).
 | <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_chunks` | Número de chunks de eventos comprimidos. |
 | <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_chunks` | Número de chunks de eventos sin comprimir. |
 
-
 ### Estadísticas de tamaño (`enable_stats_size: true`)
-
-#### Mostrar los sensores de tamaño
 
 Espacio ocupado en bytes (actualizado cada `stats_size_interval` minutos).
 
@@ -610,87 +583,24 @@ afectadas.
 
 ### Importar datos desde otras fuentes
 
-Scribe incluye scripts para importar datos desde varias fuentes.
+`migration/` contiene tres scripts que copian un historial a Scribe desde otro sitio. Se ejecutan a mano, una vez, desde una máquina que alcance ambas bases —y Scribe debe haber arrancado al menos una vez, para que sus tablas existan—.
 
-### Migración desde InfluxDB
+```bash
+cd migration
+pip install psycopg2-binary python-dotenv   # más influxdb-client para InfluxDB
+cp .env.example .env && nano .env
+python3 <script>.py
+```
 
-#### Mostrar la guía de migración de InfluxDB
+| Fuente | Script | Qué rellenar |
+| --- | --- | --- |
+| InfluxDB | `influx2scribe.py` | `INFLUX_*` |
+| LTSS | `ltss2scribe.py` | `LTSS_*` |
+| Recorder de Home Assistant | `recorder2scribe.py` | `RECORDER_*`, con `RECORDER_TYPE` en `postgres` o `sqlite` (SQLite solo necesita `RECORDER_DB_PATH`) |
 
-1. Sitúate en el directorio `migration`:
-   ```bash
-   cd migration
-   ```
+Cada ejecución necesita además `SCRIBE_*` —el destino— y los ajustes de migración: `MIGRATION_START_TIME`, `MIGRATION_END_TIME`, `CHUNK_SIZE` (horas por lote) y `PURGE_DESTINATION`, que **borra el historial del destino antes de importar**. Déjelo en `False` salvo que sea lo que quiere.
 
-2. Instala las dependencias:
-   ```bash
-   pip install influxdb-client psycopg2-binary python-dotenv
-   ```
-
-3. Configura la migración:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Rellena [InfluxDB Configuration], [Scribe Configuration] y [Migration Settings]
-   ```
-
-4. Ejecuta la migración:
-   ```bash
-   python3 influx2scribe.py
-   ```
-
-
-### Migración desde LTSS
-
-#### Mostrar la guía de migración de LTSS
-
-1. Sitúate en el directorio `migration`:
-   ```bash
-   cd migration
-   ```
-
-2. Instala las dependencias:
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Configura la migración:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Rellena [LTSS Configuration], [Scribe Configuration] y [Migration Settings]
-   ```
-
-4. Ejecuta la migración:
-   ```bash
-   python3 ltss2scribe.py
-   ```
-
-
-### Migración desde Recorder
-
-#### Mostrar la guía de migración de Recorder
-
-1. Sitúate en el directorio `migration`:
-   ```bash
-   cd migration
-   ```
-
-2. Instala las dependencias:
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Configura la migración:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Rellena [Recorder Configuration], [Scribe Configuration] y [Migration Settings]
-   ```
-
-4. Ejecuta la migración:
-   ```bash
-   python3 recorder2scribe.py
-   ```
+Cada script comprueba el esquema de destino antes de escribir nada, y se detiene con una explicación en lugar de un muro de errores fila a fila si Scribe nunca lo inicializó.
 
 </details>
 
@@ -766,17 +676,7 @@ Loops), esenciales para el rendimiento de Scribe con grandes volúmenes.
 
 </details>
 
-<details>
-<summary><b>🔗 Proyectos relacionados</b></summary>
-<br>
-
-Estos proyectos funcionan muy bien con Scribe:
-
-- [Scribe Card](https://github.com/jonathan-gtd/scribe-card): la tarjeta acompañante — cualquier consulta de su historial, en un panel.
-- [timescale_database_reader](https://github.com/remmob/timescale_database_reader): un componente personalizado para volver a leer datos de TimescaleDB en sensores de Home Assistant.
-- [timescale-plotly-card](https://github.com/remmob/timescale-plotly-card): una tarjeta basada en Plotly, muy personalizable, capaz de consultar TimescaleDB directamente.
-
-</details>
+---
 
 ## Licencia
 

--- a/README.es.md
+++ b/README.es.md
@@ -11,7 +11,7 @@ Cada estado y cada evento, mediante `asyncpg` — sin bloquear el bucle de event
 
 [![Release](https://img.shields.io/github/v/release/jonathan-gtd/scribe?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases/latest) [![Downloads](https://img.shields.io/github/downloads/jonathan-gtd/scribe/total?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases) [![Tests](https://img.shields.io/github/actions/workflow/status/jonathan-gtd/scribe/tests.yaml?branch=master&label=tests)](https://github.com/jonathan-gtd/scribe/actions/workflows/tests.yaml) [![License](https://img.shields.io/github/license/jonathan-gtd/scribe?color=lightgrey)](LICENSE)
 
-[![lang en](https://img.shields.io/badge/lang-en-lightgrey)](README.md) [![lang fr](https://img.shields.io/badge/lang-fr-lightgrey)](README.fr.md) [![lang es](https://img.shields.io/badge/lang-es-41BDF5)](README.es.md) [![lang de](https://img.shields.io/badge/lang-de-lightgrey)](README.de.md)
+[![lang en](https://img.shields.io/badge/lang-en-lightgrey)](README.md) [![lang fr](https://img.shields.io/badge/lang-fr-lightgrey)](README.fr.md) [![lang es](https://img.shields.io/badge/lang-es-41BDF5)](README.es.md) [![lang de](https://img.shields.io/badge/lang-de-lightgrey)](README.de.md) [![lang nl](https://img.shields.io/badge/lang-nl-lightgrey)](README.nl.md)
 
 </div>
 
@@ -474,7 +474,7 @@ data:
 response_variable: purged
 ```
 
-El historial comprimido también se purga: TimescaleDB se encarga y los chunks siguen comprimidos. Para una ventana deslizante que se aplique continuamente, use los ajustes de *retención* más abajo: una purga es puntual.
+El historial comprimido también se purga: TimescaleDB se encarga y los chunks siguen comprimidos. Para una ventana deslizante que se aplique continuamente, use los ajustes de *Retención* más abajo: una purga es puntual.
 
 </details>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -11,7 +11,7 @@ Chaque état et chaque événement, via `asyncpg` — sans bloquer la boucle d'�
 
 [![Release](https://img.shields.io/github/v/release/jonathan-gtd/scribe?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases/latest) [![Downloads](https://img.shields.io/github/downloads/jonathan-gtd/scribe/total?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases) [![Tests](https://img.shields.io/github/actions/workflow/status/jonathan-gtd/scribe/tests.yaml?branch=master&label=tests)](https://github.com/jonathan-gtd/scribe/actions/workflows/tests.yaml) [![License](https://img.shields.io/github/license/jonathan-gtd/scribe?color=lightgrey)](LICENSE)
 
-[![lang en](https://img.shields.io/badge/lang-en-lightgrey)](README.md) [![lang fr](https://img.shields.io/badge/lang-fr-41BDF5)](README.fr.md) [![lang es](https://img.shields.io/badge/lang-es-lightgrey)](README.es.md) [![lang de](https://img.shields.io/badge/lang-de-lightgrey)](README.de.md)
+[![lang en](https://img.shields.io/badge/lang-en-lightgrey)](README.md) [![lang fr](https://img.shields.io/badge/lang-fr-41BDF5)](README.fr.md) [![lang es](https://img.shields.io/badge/lang-es-lightgrey)](README.es.md) [![lang de](https://img.shields.io/badge/lang-de-lightgrey)](README.de.md) [![lang nl](https://img.shields.io/badge/lang-nl-lightgrey)](README.nl.md)
 
 </div>
 
@@ -476,7 +476,7 @@ data:
 response_variable: purged
 ```
 
-L'historique compressé est purgé lui aussi : TimescaleDB s'en charge et les chunks restent compressés. Pour une fenêtre glissante appliquée en continu, utilisez plutôt les réglages de *rétention* plus bas : une purge est ponctuelle.
+L'historique compressé est purgé lui aussi : TimescaleDB s'en charge et les chunks restent compressés. Pour une fenêtre glissante appliquée en continu, utilisez plutôt les réglages de *Rétention* plus bas : une purge est ponctuelle.
 
 </details>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -25,6 +25,8 @@ Le recorder de Home Assistant garde quelques semaines d'historique dans SQLite e
 - 🧩 **Le contexte avec** — entités, appareils, pièces, utilisateurs et intégrations, pas seulement des valeurs.
 - 🩺 **Il dit quand quelque chose ne va pas**, dans Repairs plutôt que dans un journal que personne ne lit.
 
+---
+
 ## Installation
 
 **1. Une base TimescaleDB.** L'extension est obligatoire — voir *Installer TimescaleDB* plus bas.
@@ -52,11 +54,11 @@ scribe:
 
 Voilà — les états sont enregistrés, découpés et compressés, avec le contexte entité, appareil et pièce. Tout ce qui suit est facultatif.
 
+---
+
 <details>
 <summary><b>🧩 Scribe Card — des graphiques sur votre tableau de bord</b></summary>
 <br>
-
-[![Scribe Card](https://raw.githubusercontent.com/jonathan-gtd/scribe-card/master/docs/screenshot.png)](https://github.com/jonathan-gtd/scribe-card)
 
 **[Scribe Card](https://github.com/jonathan-gtd/scribe-card)** affiche n'importe quelle requête de votre historique sur un tableau de bord. Dessinée avec Apache ECharts — la bibliothèque qu'utilisent les graphiques d'historique de Home Assistant — et configurée dans un formulaire, où le type de graphique, l'unité et les axes se choisissent parmi les colonnes que votre requête renvoie.
 
@@ -72,8 +74,7 @@ Elle passe par le service `scribe.query`, donc **aucune seconde connexion à la 
 
 Il vous faut une instance TimescaleDB en fonctionnement. Je recommande PostgreSQL 17 ou 18.
 
-> [!IMPORTANT]
-> **L'extension TimescaleDB est obligatoire.** Le découpage en chunks, la
+> **❗ Important** — **L'extension TimescaleDB est obligatoire.** Le découpage en chunks, la
 > compression, la rétention et les capteurs de taille sont toute la raison
 > d'être de Scribe, et aucun n'existe sur PostgreSQL nu. Une nouvelle
 > installation est refusée si l'extension manque — Scribe l'active toutefois
@@ -118,49 +119,63 @@ GRANT ALL ON SCHEMA public TO scribe;
 
 ### Configuration complète (valeurs par défaut)
 
-#### Afficher la configuration YAML complète
-
 ```yaml
 scribe:
+  # La seule option obligatoire.
   db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
-  db_ssl: false
-  ssl_root_cert: ""      # utilisé uniquement si db_ssl vaut true
-  ssl_cert_file: ""
-  ssl_key_file: ""
-  db_schema: ""      # vide = le schéma de la connexion
-  chunk_time_interval: "7 days"
-  compress_after: "7 days"
-  retention_states: ""   # vide = conservation illimitée
-  retention_events: ""   # vide = conservation illimitée
-  record_states: true
-  record_events: false
-  batch_size: 500
-  flush_interval: 5
-  max_queue_size: 10000
-  query_timeout: 60
-  query_max_rows: 20000
-  buffer_on_failure: true
-  enable_stats_io: false
-  enable_stats_chunk: false
-  enable_stats_size: false
-  stats_io_interval: 60
-  stats_chunk_interval: 60
-  stats_size_interval: 60
-  include_domains: []
-  include_entities: []
-  include_entity_globs: []
-  exclude_domains: []
+
+  # Tout le reste est facultatif. Voici les valeurs par défaut.
+
+  # Où il enregistre
+  db_schema: ""                 # vide = le schéma de la connexion, normalement public
+  db_ssl: false                 # TLS vers la base
+  ssl_root_cert: ""             # certificat CA ; lu uniquement si db_ssl est true
+  ssl_cert_file: ""             # certificat client, pour le TLS mutuel
+  ssl_key_file: ""              # sa clé privée
+
+  # Ce qu'il enregistre
+  record_states: true           # les changements d'état
+  record_events: false          # les événements Home Assistant (automatisations, scripts…)
+  include_domains: []           # vide = tous les domaines
+  include_entities: []          # vide = toutes les entités
+  include_entity_globs: []      # ex. sensor.meteo_*
+  exclude_domains: []           # appliqué après les listes d'inclusion
   exclude_entities: []
   exclude_entity_globs: []
-  exclude_attributes: []
-  include_events: []
-  exclude_events: []
-  # Optionnel : désactiver certaines tables de métadonnées (défaut : true)
+  exclude_attributes: []        # attributs retirés de la colonne attributes
+  include_events: []            # vide = tous les types d'événements
+  exclude_events: []            # appliqué après include_events
+
+  # Combien de temps il le garde
+  chunk_time_interval: "7 days" # durée couverte par un chunk
+  compress_after: "7 days"      # les chunks plus vieux que ça sont compressés
+  retention_states: ""          # vide = pour toujours ; sinon SUPPRIME les états plus anciens
+  retention_events: ""          # vide = pour toujours ; sinon SUPPRIME les événements plus anciens
+  enable_rollups: false         # résumés horaires et journaliers des états numériques
+
+  # Comment il écrit
+  batch_size: 500               # lignes mises en tampon avant une écriture
+  flush_interval: 5             # secondes avant d'écrire un lot incomplet
+  max_queue_size: 10000         # lignes gardées en mémoire avant d'écarter les nouvelles
+  buffer_on_failure: true       # continuer à tamponner tant que la base est injoignable
+
+  # Ce que scribe.query a le droit de coûter
+  query_timeout: 60             # secondes qu'une requête peut durer
+  query_max_rows: 20000         # lignes qu'elle peut renvoyer avant d'être refusée
+
+  # Capteurs sur Scribe lui-même
+  enable_stats_io: false        # compteurs du writer, lus en mémoire
+  enable_stats_chunk: false     # nombre de chunks, une requête par rafraîchissement
+  enable_stats_size: false      # tailles sur disque, une requête par rafraîchissement
+  stats_io_interval: 60         # secondes entre deux valeurs d'écriture
+  stats_chunk_interval: 60      # minutes entre deux requêtes de chunks
+  stats_size_interval: 60       # minutes entre deux requêtes de taille
+
+  # Tables de contexte, synchronisées avec les registres de Home Assistant
   enable_table_areas: true
   enable_table_devices: true
   enable_table_integrations: true
   enable_table_users: true
-  enable_rollups: false
 ```
 
 </details>
@@ -169,8 +184,6 @@ scribe:
 <summary><b>📋 Référence des paramètres</b></summary>
 <br>
 
-#### Afficher la référence des paramètres
-
 | Paramètre | Description |
 | :--- | :--- |
 | `db_url` | **Obligatoire.** Chaîne de connexion vers votre base TimescaleDB. |
@@ -178,11 +191,11 @@ scribe:
 | `ssl_root_cert` | Chemin vers le fichier CA (ex. `/ssl/ca.crt`). Un chemin relatif est résolu depuis le répertoire de configuration de Home Assistant. |
 | `ssl_cert_file` | Chemin vers le certificat client, pour le TLS mutuel. |
 | `ssl_key_file` | Chemin vers la clé privée client, pour le TLS mutuel. |
-| `db_schema` | Schéma PostgreSQL dans lequel enregistrer. Vide (défaut) : celui de la connexion, normalement `public`. Voir [Schéma de la base de données](#schéma-de-la-base-de-données). |
-| `chunk_time_interval` | Durée couverte par chaque chunk de la table. Voir [Réglage du stockage](#réglage-du-stockage). |
-| `compress_after` | Les chunks plus anciens que cet intervalle sont compressés. Voir [Réglage du stockage](#réglage-du-stockage). |
-| `retention_states` | **Supprime** l'historique des états plus ancien que cet intervalle (ex. `"365 days"`). Vide (défaut) : tout est conservé. Voir [Rétention](#rétention). |
-| `retention_events` | **Supprime** l'historique des événements plus ancien que cet intervalle. Vide (défaut) : tout est conservé. Voir [Rétention](#rétention). |
+| `db_schema` | Schéma PostgreSQL dans lequel enregistrer. Vide (défaut) : celui de la connexion, normalement `public`. |
+| `chunk_time_interval` | Durée couverte par chaque chunk de la table. Voir *Réglage du stockage* plus bas. |
+| `compress_after` | Les chunks plus anciens que cet intervalle sont compressés. Voir *Réglage du stockage* plus bas. |
+| `retention_states` | **Supprime** l'historique des états plus ancien que cet intervalle (ex. `"365 days"`). Vide (défaut) : tout est conservé. Voir *Rétention* plus bas. |
+| `retention_events` | **Supprime** l'historique des événements plus ancien que cet intervalle. Vide (défaut) : tout est conservé. Voir *Rétention* plus bas. |
 | `record_states` | Enregistrer ou non les changements d'état. |
 | `record_events` | Enregistrer ou non les événements. |
 | `batch_size` | Nombre d'éléments mis en tampon avant écriture en base. |
@@ -224,7 +237,7 @@ physiquement découpée en **chunks**, chacun couvrant une tranche de temps.
 Presque tout ce qui touche à l'espace disque et à la vitesse des requêtes
 découle de ce découpage — une requête sur la semaine dernière ne lit que les
 chunks qui la recouvrent, la compression travaille chunk par chunk, et la
-[rétention](#rétention) supprime des chunks entiers plutôt que des lignes.
+*rétention* plus bas supprime des chunks entiers plutôt que des lignes.
 
 Deux réglages le pilotent, en YAML comme dans l'interface sous
 **Configurer → Avancé (TimescaleDB & SSL)** :
@@ -311,8 +324,7 @@ scribe:
 Les deux sont aussi disponibles dans l'interface, sous
 **Configurer → Avancé (TimescaleDB & SSL)**.
 
-> [!WARNING]
-> La rétention **supprime les données définitivement**. Il n'y a ni annulation
+> **⚠️ Attention** — La rétention **supprime les données définitivement**. Il n'y a ni annulation
 > ni corbeille : dès qu'un chunk sort de la fenêtre, il est supprimé, et seule
 > une sauvegarde peut le ramener. États et événements se configurent séparément,
 > ce qui permet de faire expirer des événements bavards tout en conservant
@@ -362,7 +374,7 @@ scribe:
   enable_rollups: true
 ```
 
-Cela ajoute deux vues :
+C'est aussi dans l'interface, sous **Configurer → Tables de métadonnées**. Cela ajoute deux vues :
 
 | Vue | Une ligne par | Colonnes |
 | --- | --- | --- |
@@ -377,19 +389,17 @@ WHERE entity_id = 'sensor.temperature_exterieure'
 ORDER BY bucket;
 ```
 
-Seuls les états numériques sont résumés — la moyenne de `on` et `off` n'a aucun sens — et `samples` indique combien d'états chaque ligne représente.
+Seuls les états numériques sont résumés — la moyenne de `on` et `off` n'a aucun sens — donc `value_avg`, `value_min` et `value_max` sont vides pour les autres, tandis que `samples` compte tous les états du bucket.
 
-**Ce sont des données dérivées.** Rien de ce qui compte n'est dupliqué : désactiver l'option supprime les deux vues, la réactiver les reconstruit depuis l'historique, et vos états ne sont jamais touchés. TimescaleDB les maintient lui-même ; Scribe se contente de les créer.
+**Ce sont des données dérivées.** Rien de ce qui compte n'est dupliqué : désactiver l'option supprime les deux vues, la réactiver les reconstruit depuis l'historique, et vos états ne sont jamais touchés. TimescaleDB les rafraîchit lui-même — l'horaire toutes les 30 minutes, le journalier toutes les heures — et chaque passage regarde assez loin en arrière (3 jours, 30 jours) pour qu'un lot écrit en retard y arrive quand même. Scribe se contente de les créer.
 
 </details>
 
 <details>
-<summary><b>🗃️ Schéma de la base — tables, vues et comment les interroger</b></summary>
+<summary><b>🗃️ Enregistrer dans un schéma PostgreSQL précis</b></summary>
 <br>
 
-Par défaut, Scribe enregistre dans le schéma vers lequel votre connexion pointe
-déjà — normalement `public`. Renseignez `db_schema` et il crée ce schéma et y
-place tout : ses tables, ses vues, ses hypertables et ses politiques.
+Par défaut, Scribe enregistre dans le schéma vers lequel pointe déjà votre connexion — normalement `public`. Renseignez `db_schema` et il crée ce schéma et y met tout : ses tables, ses vues, ses hypertables et ses politiques.
 
 ```yaml
 scribe:
@@ -397,47 +407,17 @@ scribe:
   db_schema: scribe
 ```
 
-L'option est aussi dans l'interface, sous **Configurer → Avancé (TimescaleDB &
-SSL)**.
+C'est aussi dans l'interface, sous **Configurer → Avancé (TimescaleDB & SSL)**.
 
-C'est ce qu'il vous faut quand Scribe partage une base avec autre chose : vos
-propres copies transformées de l'historique, les tables d'une autre intégration,
-ou un second Home Assistant qui enregistre sur le même serveur. Chaque schéma est
-indépendant — tables, hypertables, politiques de rétention et de compression
-distinctes — et rien de ce que Scribe fait dans l'un n'atteint l'autre.
+C'est ce qu'il vous faut quand Scribe partage une base avec autre chose : les tables d'une autre intégration, vos propres copies de l'historique, ou un second Home Assistant qui enregistre sur le même serveur. Les schémas sont indépendants — tables, hypertables, rétention et compression séparées — et rien de ce que Scribe fait dans l'un n'atteint l'autre.
 
-À savoir :
+- **Seules les nouvelles données y vont.** Renseigner `db_schema` ne déplace pas l'historique déjà enregistré. Déplacez-le vous-même avant de redémarrer (`ALTER TABLE public.states_raw SET SCHEMA scribe;`), ou interrogez l'ancien schéma directement.
+- **Scribe crée le schéma s'il le peut**, ce qui demande `CREATE` sur la base. Un schéma que vous avez créé à la main convient aussi, avec `USAGE` et `CREATE` dessus.
+- **Un schéma inaccessible arrête l'enregistrement.** PostgreSQL passe à l'entrée suivante du search path au lieu d'échouer : une faute de frappe remplirait donc `public` pendant que l'interface affiche autre chose. Scribe vérifie où il a atterri et n'enregistre rien plutôt que d'enregistrer au mauvais endroit, avec un problème dans Réparations qui dit quoi accorder.
+- **Vos requêtes ne changent pas.** Scribe place le schéma en tête du `search_path` de la connexion, donc `SELECT * FROM states` continue de marcher via `scribe.query`. Depuis Grafana ou psql, qualifiez le nom (`scribe.states`) ou définissez votre propre `search_path`. `public` reste sur le chemin — c'est là que vivent les fonctions TimescaleDB.
+- Les valeurs acceptées sont de simples identifiants : lettres, chiffres et tirets bas, ne commençant pas par un chiffre. Vide garde le schéma de la connexion, y compris un que vous auriez fixé vous-même avec `?options=-csearch_path%3Dmonschema` dans l'URL.
 
-- **Seules les nouvelles données y vont.** Renseigner `db_schema` ne déplace pas
-  l'historique déjà enregistré : Scribe crée un jeu de tables vide dans le
-  nouveau schéma et commence à y écrire. Pour conserver l'ancien historique,
-  déplacez-le vous-même (`ALTER TABLE public.states_raw SET SCHEMA scribe;`)
-  avant le redémarrage, ou interrogez directement l'ancien schéma.
-- **Scribe crée le schéma s'il le peut.** L'utilisateur de la base a besoin du
-  droit `CREATE` sur celle-ci. Un schéma créé par quelqu'un d'autre convient tout
-  aussi bien, tant que l'utilisateur y a `USAGE` et `CREATE` :
-  ```sql
-  CREATE SCHEMA IF NOT EXISTS scribe;
-  GRANT USAGE, CREATE ON SCHEMA scribe TO scribe;
-  ```
-- **Un schéma inaccessible arrête l'enregistrement.** PostgreSQL n'échoue pas
-  sur un schéma absent — il passe silencieusement à l'entrée suivante du search
-  path — de sorte qu'une faute de frappe ou un droit manquant remplirait
-  `public` pendant que l'interface afficherait autre chose. Scribe vérifie où il
-  a réellement atterri et n'enregistre rien plutôt que d'enregistrer au mauvais
-  endroit, avec un problème dans Réparations qui explique quels droits accorder.
-- **Vos requêtes ne changent pas.** Scribe place le schéma en tête du
-  `search_path` de la connexion, donc `SELECT * FROM states` continue de
-  fonctionner via le service `scribe.query`. Depuis ailleurs — Grafana, psql, un
-  tableau de bord — qualifiez le nom (`scribe.states`) ou définissez votre propre
-  `search_path`.
-- **`public` reste dans le chemin.** C'est là que l'extension TimescaleDB
-  installe `create_hypertable()` et consorts, que Scribe doit appeler.
-- Les valeurs acceptées sont des identifiants simples : lettres, chiffres et
-  tirets bas, ne commençant pas par un chiffre. Laissez vide pour continuer à
-  utiliser le schéma de la connexion — y compris celui que vous avez défini
-  vous-même avec `?options=-csearch_path%3Dmonschema` dans l'URL, que Scribe
-  suit sans le remplacer.
+**Les tables elles-mêmes** — chaque colonne, leurs relations, et des recettes de requêtes pour Grafana et `scribe.query` — sont documentées dans [`docs/data-structure.md`](docs/data-structure.md).
 
 </details>
 
@@ -496,7 +476,7 @@ data:
 response_variable: purged
 ```
 
-L'historique compressé est purgé lui aussi : TimescaleDB s'en charge et les chunks restent compressés. Pour une fenêtre glissante appliquée en continu, utilisez plutôt les réglages de [rétention](#rétention) : une purge est ponctuelle.
+L'historique compressé est purgé lui aussi : TimescaleDB s'en charge et les chunks restent compressés. Pour une fenêtre glissante appliquée en continu, utilisez plutôt les réglages de *rétention* plus bas : une purge est ponctuelle.
 
 </details>
 
@@ -508,8 +488,6 @@ Activez les capteurs en positionnant leurs options dans votre configuration.
 
 ### Statistiques d'écriture (`enable_stats_io: true`)
 
-#### Afficher les capteurs d'écriture
-
 Mesures en temps réel issues de l'écrivain (aucune requête en base).
 
 | Capteur | Description |
@@ -517,14 +495,11 @@ Mesures en temps réel issues de l'écrivain (aucune requête en base).
 | <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_states_written` | Nombre total de changements d'état écrits en base. |
 | <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_events_written` | Nombre total d'événements écrits en base. |
 | <img src="https://api.iconify.design/mdi:buffer.svg?color=%232196F3" width="15" /> `sensor.scribe_buffer_size` | Nombre d'éléments actuellement en attente dans le tampon mémoire. |
-| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_write_duration` | Durée (en ms) de la dernière écriture en base. |
+| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_last_write_duration` | Durée (en ms) de la dernière écriture en base. |
 | <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_states_rate` | Débit d'états écrits en base (par minute). |
 | <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_events_rate` | Débit d'événements écrits en base (par minute). |
 
-
 ### Statistiques de chunks (`enable_stats_chunk: true`)
-
-#### Afficher les capteurs de chunks
 
 Nombre de chunks (mis à jour toutes les `stats_chunk_interval` minutes).
 
@@ -537,10 +512,7 @@ Nombre de chunks (mis à jour toutes les `stats_chunk_interval` minutes).
 | <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_chunks` | Nombre de chunks d'événements compressés. |
 | <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_chunks` | Nombre de chunks d'événements non compressés. |
 
-
 ### Statistiques de taille (`enable_stats_size: true`)
-
-#### Afficher les capteurs de taille
 
 Espace occupé, en octets (mis à jour toutes les `stats_size_interval` minutes).
 
@@ -614,87 +586,24 @@ concernées.
 
 ### Reprise de données depuis d'autres sources
 
-Scribe fournit des scripts pour reprendre des données depuis diverses sources.
+`migration/` contient trois scripts qui recopient un historique dans Scribe depuis ailleurs. Ils se lancent à la main, une fois, depuis une machine qui atteint les deux bases — et Scribe doit avoir démarré au moins une fois, pour que ses tables existent.
 
-### Migration InfluxDB
+```bash
+cd migration
+pip install psycopg2-binary python-dotenv   # plus influxdb-client pour InfluxDB
+cp .env.example .env && nano .env
+python3 <script>.py
+```
 
-#### Afficher le guide de migration InfluxDB
+| Source | Script | À renseigner |
+| --- | --- | --- |
+| InfluxDB | `influx2scribe.py` | `INFLUX_*` |
+| LTSS | `ltss2scribe.py` | `LTSS_*` |
+| Recorder de Home Assistant | `recorder2scribe.py` | `RECORDER_*`, avec `RECORDER_TYPE` à `postgres` ou `sqlite` (SQLite ne demande que `RECORDER_DB_PATH`) |
 
-1. Placez-vous dans le répertoire `migration` :
-   ```bash
-   cd migration
-   ```
+Chaque exécution a aussi besoin de `SCRIBE_*` — la destination — et des réglages de migration : `MIGRATION_START_TIME`, `MIGRATION_END_TIME`, `CHUNK_SIZE` (heures par lot) et `PURGE_DESTINATION`, qui **supprime l'historique de la destination avant d'importer**. Laissez-le à `False` sauf si c'est voulu.
 
-2. Installez les dépendances :
-   ```bash
-   pip install influxdb-client psycopg2-binary python-dotenv
-   ```
-
-3. Configurez la migration :
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Renseignez [InfluxDB Configuration], [Scribe Configuration] et [Migration Settings]
-   ```
-
-4. Lancez la migration :
-   ```bash
-   python3 influx2scribe.py
-   ```
-
-
-### Migration LTSS
-
-#### Afficher le guide de migration LTSS
-
-1. Placez-vous dans le répertoire `migration` :
-   ```bash
-   cd migration
-   ```
-
-2. Installez les dépendances :
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Configurez la migration :
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Renseignez [LTSS Configuration], [Scribe Configuration] et [Migration Settings]
-   ```
-
-4. Lancez la migration :
-   ```bash
-   python3 ltss2scribe.py
-   ```
-
-
-### Migration Recorder
-
-#### Afficher le guide de migration Recorder
-
-1. Placez-vous dans le répertoire `migration` :
-   ```bash
-   cd migration
-   ```
-
-2. Installez les dépendances :
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Configurez la migration :
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Renseignez [Recorder Configuration], [Scribe Configuration] et [Migration Settings]
-   ```
-
-4. Lancez la migration :
-   ```bash
-   python3 recorder2scribe.py
-   ```
+Chaque script vérifie le schéma de destination avant d'écrire quoi que ce soit, et s'arrête avec une explication plutôt qu'un mur d'erreurs ligne par ligne si Scribe ne l'a jamais initialisé.
 
 </details>
 
@@ -772,17 +681,7 @@ volumes.
 
 </details>
 
-<details>
-<summary><b>🔗 Projets liés</b></summary>
-<br>
-
-Ces projets fonctionnent très bien avec Scribe :
-
-- [Scribe Card](https://github.com/jonathan-gtd/scribe-card) : la carte compagnon — n'importe quelle requête de votre historique, sur un tableau de bord.
-- [timescale_database_reader](https://github.com/remmob/timescale_database_reader) : un composant personnalisé pour relire les données de TimescaleDB dans des capteurs Home Assistant.
-- [timescale-plotly-card](https://github.com/remmob/timescale-plotly-card) : une carte Plotly très personnalisable, capable d'interroger TimescaleDB directement.
-
-</details>
+---
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Every state and every event, through `asyncpg` — without blocking the event lo
 
 [![Release](https://img.shields.io/github/v/release/jonathan-gtd/scribe?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases/latest) [![Downloads](https://img.shields.io/github/downloads/jonathan-gtd/scribe/total?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases) [![Tests](https://img.shields.io/github/actions/workflow/status/jonathan-gtd/scribe/tests.yaml?branch=master&label=tests)](https://github.com/jonathan-gtd/scribe/actions/workflows/tests.yaml) [![License](https://img.shields.io/github/license/jonathan-gtd/scribe?color=lightgrey)](LICENSE)
 
-[![lang en](https://img.shields.io/badge/lang-en-41BDF5)](README.md) [![lang fr](https://img.shields.io/badge/lang-fr-lightgrey)](README.fr.md) [![lang es](https://img.shields.io/badge/lang-es-lightgrey)](README.es.md) [![lang de](https://img.shields.io/badge/lang-de-lightgrey)](README.de.md)
+[![lang en](https://img.shields.io/badge/lang-en-41BDF5)](README.md) [![lang fr](https://img.shields.io/badge/lang-fr-lightgrey)](README.fr.md) [![lang es](https://img.shields.io/badge/lang-es-lightgrey)](README.es.md) [![lang de](https://img.shields.io/badge/lang-de-lightgrey)](README.de.md) [![lang nl](https://img.shields.io/badge/lang-nl-lightgrey)](README.nl.md)
 
 </div>
 
@@ -232,7 +232,7 @@ Scribe stores history in TimescaleDB **hypertables**: a table that looks and
 queries like any other, but is physically split into **chunks**, each covering a
 slice of time. Almost everything about Scribe's disk usage and query speed comes
 down to that split — a query for last week reads only the chunks that overlap
-last week, compression works one chunk at a time, and *retention* below
+last week, compression works one chunk at a time, and *Retention* below
 deletes whole chunks rather than individual rows.
 
 Two settings control it, both in YAML and in the UI under **Configure →
@@ -460,7 +460,7 @@ data:
 response_variable: purged
 ```
 
-Compressed history is purged as well; TimescaleDB handles it, and the chunks stay compressed. For a rolling window you want to keep applying, use the *retention* below settings instead: a purge is a one-off.
+Compressed history is purged as well; TimescaleDB handles it, and the chunks stay compressed. For a rolling window you want to keep applying, use the *Retention* settings below instead: a purge is a one-off.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Home Assistant's recorder keeps a few weeks of history in SQLite and slows down 
 - 🧩 **Context included** — entities, devices, areas, users and integrations, not only values.
 - 🩺 **It says when something is wrong**, in Repairs rather than in a log nobody reads.
 
+---
+
 ## Install
 
 **1. A TimescaleDB database.** The extension is required — see *Setting up TimescaleDB* below.
@@ -52,11 +54,11 @@ scribe:
 
 Done — states recorded, chunked and compressed, with their entity, device and area context. Everything below is optional.
 
+---
+
 <details>
 <summary><b>🧩 Scribe Card — charts on your dashboard</b></summary>
 <br>
-
-[![Scribe Card](https://raw.githubusercontent.com/jonathan-gtd/scribe-card/master/docs/screenshot.png)](https://github.com/jonathan-gtd/scribe-card)
 
 **[Scribe Card](https://github.com/jonathan-gtd/scribe-card)** puts any query from your history on a dashboard. Drawn with Apache ECharts — what Home Assistant's own history charts use — and configured in a form, with the chart type, the unit and the axes picked from the columns your query returns.
 
@@ -70,8 +72,7 @@ It talks to Scribe through the `scribe.query` service, so there is **no second d
 
 You need a running TimescaleDB instance. I recommend PostgreSQL 17 or 18.
 
-> [!IMPORTANT]
-> **The TimescaleDB extension is required.** Chunking, compression, retention
+> **❗ Important** — **The TimescaleDB extension is required.** Chunking, compression, retention
 > and the size sensors are the whole point of Scribe, and none of them exist on
 > plain PostgreSQL. A new installation is refused if the extension is missing —
 > although Scribe enables it for you when the server has it available and your
@@ -115,49 +116,63 @@ GRANT ALL ON SCHEMA public TO scribe;
 
 ### Full Configuration (Default Values)
 
-#### Show Full YAML Configuration
-
 ```yaml
 scribe:
+  # The only required option.
   db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
-  db_ssl: false
-  ssl_root_cert: ""      # only used when db_ssl is true
-  ssl_cert_file: ""
-  ssl_key_file: ""
-  db_schema: ""      # empty = the connection's own schema
-  chunk_time_interval: "7 days"
-  compress_after: "7 days"
-  retention_states: ""   # empty = keep forever
-  retention_events: ""   # empty = keep forever
-  record_states: true
-  record_events: false
-  batch_size: 500
-  flush_interval: 5
-  max_queue_size: 10000
-  query_timeout: 60
-  query_max_rows: 20000
-  buffer_on_failure: true
-  enable_stats_io: false
-  enable_stats_chunk: false
-  enable_stats_size: false
-  stats_io_interval: 60
-  stats_chunk_interval: 60
-  stats_size_interval: 60
-  include_domains: []
-  include_entities: []
-  include_entity_globs: []
-  exclude_domains: []
+
+  # Everything below is optional. These are the defaults.
+
+  # Where it records
+  db_schema: ""                 # empty = the connection's own schema, normally public
+  db_ssl: false                 # TLS to the database
+  ssl_root_cert: ""             # CA certificate; only read when db_ssl is true
+  ssl_cert_file: ""             # client certificate, for mutual TLS
+  ssl_key_file: ""              # its private key
+
+  # What it records
+  record_states: true           # state changes
+  record_events: false          # Home Assistant events (automations, scripts…)
+  include_domains: []           # empty = every domain
+  include_entities: []          # empty = every entity
+  include_entity_globs: []      # e.g. sensor.weather_*
+  exclude_domains: []           # applied after the include lists
   exclude_entities: []
   exclude_entity_globs: []
-  exclude_attributes: []
-  include_events: []
-  exclude_events: []
-  # Optional: Disable specific metadata tables (default: true)
+  exclude_attributes: []        # attribute names stripped from the attributes column
+  include_events: []            # empty = every event type
+  exclude_events: []            # applied after include_events
+
+  # How long it keeps it
+  chunk_time_interval: "7 days" # how much time one chunk covers
+  compress_after: "7 days"      # chunks older than this get compressed
+  retention_states: ""          # empty = forever; otherwise DELETES older states
+  retention_events: ""          # empty = forever; otherwise DELETES older events
+  enable_rollups: false         # hourly and daily summaries of numeric states
+
+  # How it writes
+  batch_size: 500               # rows buffered before a write
+  flush_interval: 5             # seconds before an incomplete batch is written anyway
+  max_queue_size: 10000         # rows held in memory before new ones are dropped
+  buffer_on_failure: true       # keep buffering while the database is unreachable
+
+  # What scribe.query may cost
+  query_timeout: 60             # seconds a query may run
+  query_max_rows: 20000         # rows it may return before it is refused
+
+  # Sensors about Scribe itself
+  enable_stats_io: false        # writer counters, read from memory
+  enable_stats_chunk: false     # chunk counts, one query per refresh
+  enable_stats_size: false      # disk sizes, one query per refresh
+  stats_io_interval: 60         # seconds between two I/O values
+  stats_chunk_interval: 60      # minutes between two chunk queries
+  stats_size_interval: 60       # minutes between two size queries
+
+  # Context tables, kept in sync with Home Assistant's registries
   enable_table_areas: true
   enable_table_devices: true
   enable_table_integrations: true
   enable_table_users: true
-  enable_rollups: false
 ```
 
 </details>
@@ -166,8 +181,6 @@ scribe:
 <summary><b>📋 Parameter reference</b></summary>
 <br>
 
-#### Show Parameter Reference
-
 | Parameter | Description |
 | :--- | :--- |
 | `db_url` | **Required.** The connection string for your TimescaleDB database. |
@@ -175,11 +188,11 @@ scribe:
 | `ssl_root_cert` | Path to the CA certificate file (e.g. `/ssl/ca.crt`). A relative path resolves from the Home Assistant config directory. |
 | `ssl_cert_file` | Path to the client certificate file, for mutual TLS. |
 | `ssl_key_file` | Path to the client private key file, for mutual TLS. |
-| `db_schema` | PostgreSQL schema to record into. Empty (default) uses the connection's own schema, normally `public`. See [Database schema](#database-schema). |
-| `chunk_time_interval` | How much time each chunk of the table covers. See [Storage tuning](#storage-tuning). |
-| `compress_after` | Chunks older than this are compressed. See [Storage tuning](#storage-tuning). |
-| `retention_states` | **Deletes** state history older than this interval (e.g. `"365 days"`). Empty (default) keeps everything. See [Retention](#retention). |
-| `retention_events` | **Deletes** event history older than this interval. Empty (default) keeps everything. See [Retention](#retention). |
+| `db_schema` | PostgreSQL schema to record into. Empty (default) uses the connection's own schema, normally `public`. |
+| `chunk_time_interval` | How much time each chunk of the table covers. See *Storage tuning* below. |
+| `compress_after` | Chunks older than this are compressed. See *Storage tuning* below. |
+| `retention_states` | **Deletes** state history older than this interval (e.g. `"365 days"`). Empty (default) keeps everything. See *Retention* below. |
+| `retention_events` | **Deletes** event history older than this interval. Empty (default) keeps everything. See *Retention* below. |
 | `record_states` | Whether to record state changes. |
 | `record_events` | Whether to record events. |
 | `batch_size` | Number of items to buffer before writing to the database. |
@@ -219,7 +232,7 @@ Scribe stores history in TimescaleDB **hypertables**: a table that looks and
 queries like any other, but is physically split into **chunks**, each covering a
 slice of time. Almost everything about Scribe's disk usage and query speed comes
 down to that split — a query for last week reads only the chunks that overlap
-last week, compression works one chunk at a time, and [retention](#retention)
+last week, compression works one chunk at a time, and *retention* below
 deletes whole chunks rather than individual rows.
 
 Two settings control it, both in YAML and in the UI under **Configure →
@@ -299,8 +312,7 @@ scribe:
 
 Both are also in the UI under **Configure → Advanced (TimescaleDB & SSL)**.
 
-> [!WARNING]
-> Retention **deletes data permanently**. There is no undo and no trip to a bin:
+> **⚠️ Warning** — Retention **deletes data permanently**. There is no undo and no trip to a bin:
 > once a chunk falls outside the window it is dropped, and only a backup brings
 > it back. States and events are configured separately so you can expire noisy
 > events while keeping state history.
@@ -346,7 +358,7 @@ scribe:
   enable_rollups: true
 ```
 
-That adds two views:
+It is also in the UI under **Configure → Metadata Tables**. That adds two views:
 
 | View | One row per | Columns |
 | --- | --- | --- |
@@ -361,20 +373,17 @@ WHERE entity_id = 'sensor.outside_temperature'
 ORDER BY bucket;
 ```
 
-Only numeric states are summarised — the average of `on` and `off` means nothing — and `samples` tells you how many states each row stands for.
+Only numeric states are summarised — the average of `on` and `off` means nothing — so `value_avg`, `value_min` and `value_max` are empty for the rest, while `samples` counts every state in the bucket.
 
-**They are derived data.** Nothing is duplicated that you would miss: turning the option off deletes both views, turning it back on rebuilds them from the history, and your states are never touched either way. TimescaleDB keeps them current itself; Scribe only creates them.
+**They are derived data.** Nothing is duplicated that you would miss: turning the option off deletes both views, turning it back on rebuilds them from the history, and your states are never touched either way. TimescaleDB refreshes them itself — the hourly one every 30 minutes, the daily one every hour — and each run looks back far enough (3 days, 30 days) that a batch written late still lands in them. Scribe only creates them.
 
 </details>
 
 <details>
-<summary><b>🗃️ Database schema — tables, views and how to query them</b></summary>
+<summary><b>🗃️ Recording into a specific PostgreSQL schema</b></summary>
 <br>
 
-By default Scribe records into whatever schema your connection already points
-at — normally `public`. Set `db_schema` and it creates that schema and puts
-everything in it instead: its tables, its views, its hypertables and its
-policies.
+By default Scribe records into whatever schema your connection already points at — normally `public`. Set `db_schema` and it creates that schema and puts everything in it instead: its tables, its views, its hypertables and its policies.
 
 ```yaml
 scribe:
@@ -384,43 +393,15 @@ scribe:
 
 It is also in the UI under **Configure → Advanced (TimescaleDB & SSL)**.
 
-This is what you want when Scribe shares a database with something else: your
-own transformed copies of the history, another integration's tables, or a second
-Home Assistant recording into the same server. Each schema is independent —
-separate tables, separate hypertables, separate retention and compression
-policies — and nothing Scribe does in one can reach the other.
+This is what you want when Scribe shares a database with something else: another integration's tables, your own copies of the history, or a second Home Assistant recording into the same server. Schemas are independent — separate tables, hypertables, retention and compression — and nothing Scribe does in one reaches the other.
 
-Details worth knowing:
+- **Only new data goes there.** Setting `db_schema` does not move history already recorded. Move it yourself before restarting (`ALTER TABLE public.states_raw SET SCHEMA scribe;`), or query the old schema directly.
+- **Scribe creates the schema if it can**, which needs `CREATE` on the database. One you created by hand works too, given `USAGE` and `CREATE` on it.
+- **An unreachable schema stops recording.** PostgreSQL falls through to the next entry on the search path instead of failing, so a typo would otherwise fill `public` while the UI showed something else. Scribe checks where it landed and records nothing rather than the wrong thing, with a Repairs issue saying what to grant.
+- **Your queries do not change.** Scribe puts the schema first on the connection's `search_path`, so `SELECT * FROM states` keeps working through `scribe.query`. From Grafana or psql, qualify the name (`scribe.states`) or set your own `search_path`. `public` stays on the path — that is where the TimescaleDB functions live.
+- Accepted values are plain identifiers: letters, digits and underscores, not starting with a digit. Empty keeps the connection's own schema, including one you set yourself with `?options=-csearch_path%3Dmyschema` in the URL.
 
-- **Only new data goes there.** Setting `db_schema` does not move history that
-  is already recorded; Scribe creates a fresh, empty set of tables in the new
-  schema and starts writing to it. To keep the old history, move it yourself
-  (`ALTER TABLE public.states_raw SET SCHEMA scribe;`) before restarting, or
-  query the old schema directly.
-- **Scribe creates the schema if it can.** The database user needs `CREATE` on
-  the database for that. A schema someone else created works just as well, as
-  long as the user has `USAGE` and `CREATE` on it:
-  ```sql
-  CREATE SCHEMA IF NOT EXISTS scribe;
-  GRANT USAGE, CREATE ON SCHEMA scribe TO scribe;
-  ```
-- **An unreachable schema stops recording.** PostgreSQL does not fail on a
-  missing schema — it quietly falls through to the next entry on the search
-  path — so a typo or a missing grant would otherwise fill `public` while the UI
-  showed something else. Scribe checks where it actually landed and records
-  nothing rather than the wrong thing, with a Repairs issue explaining what to
-  grant.
-- **Your queries do not change.** Scribe puts the schema first on the
-  connection's `search_path`, so `SELECT * FROM states` keeps working through
-  the `scribe.query` service. From anywhere else — Grafana, psql, a dashboard —
-  either qualify the name (`scribe.states`) or set your own `search_path`.
-- **`public` stays on the path.** That is where the TimescaleDB extension
-  installs `create_hypertable()` and friends, which Scribe needs to call.
-- Accepted values are plain identifiers: letters, digits and underscores, not
-  starting with a digit. Leave it empty to keep using the connection's own
-  schema — including one you set yourself with
-  `?options=-csearch_path%3Dmyschema` in the URL, which Scribe follows and does
-  not override.
+**The tables themselves** — every column, how they relate, and query recipes for Grafana and `scribe.query` — are documented in [`docs/data-structure.md`](docs/data-structure.md).
 
 </details>
 
@@ -479,7 +460,7 @@ data:
 response_variable: purged
 ```
 
-Compressed history is purged as well; TimescaleDB handles it, and the chunks stay compressed. For a rolling window you want to keep applying, use the [retention](#retention) settings instead: a purge is a one-off.
+Compressed history is purged as well; TimescaleDB handles it, and the chunks stay compressed. For a rolling window you want to keep applying, use the *retention* below settings instead: a purge is a one-off.
 
 </details>
 
@@ -491,8 +472,6 @@ Enable sensors by setting their flags in your configuration.
 
 ### IO Statistics (`enable_stats_io: true`)
 
-#### Show IO Sensors
-
 Real-time metrics from the writer (no DB queries).
 
 | Sensor | Description |
@@ -500,14 +479,11 @@ Real-time metrics from the writer (no DB queries).
 | <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_states_written` | Total number of state changes written to the DB. |
 | <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_events_written` | Total number of events written to the DB. |
 | <img src="https://api.iconify.design/mdi:buffer.svg?color=%232196F3" width="15" /> `sensor.scribe_buffer_size` | Current number of items waiting in the memory buffer. |
-| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_write_duration` | Time taken (in ms) for the last database write operation. |
+| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_last_write_duration` | Time taken (in ms) for the last database write operation. |
 | <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_states_rate` | Rate of states written to DB (per minute). |
 | <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_events_rate` | Rate of events written to DB (per minute). |
 
-
 ### Chunk Statistics (`enable_stats_chunk: true`)
-
-#### Show Chunk Sensors
 
 Chunk counts (updated every `stats_chunk_interval` minutes).
 
@@ -520,10 +496,7 @@ Chunk counts (updated every `stats_chunk_interval` minutes).
 | <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_chunks` | Number of compressed event chunks. |
 | <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_chunks` | Number of uncompressed event chunks. |
 
-
 ### Size Statistics (`enable_stats_size: true`)
-
-#### Show Size Sensors
 
 Storage usage in bytes (updated every `stats_size_interval` minutes).
 
@@ -591,87 +564,24 @@ Fresh installs and any database created by 3.x are unaffected.
 
 ### Backfilling from other sources
 
-Scribe provided helper scripts to backfill data from various sources.
+`migration/` holds three scripts that copy history into Scribe from somewhere else. They are run by hand, once, from a machine that reaches both databases — and Scribe must have started at least once, so its tables exist.
 
-### InfluxDB Migration
+```bash
+cd migration
+pip install psycopg2-binary python-dotenv   # plus influxdb-client for InfluxDB
+cp .env.example .env && nano .env
+python3 <script>.py
+```
 
-#### Show InfluxDB Migration Guide
+| Source | Script | What to fill in |
+| --- | --- | --- |
+| InfluxDB | `influx2scribe.py` | `INFLUX_*` |
+| LTSS | `ltss2scribe.py` | `LTSS_*` |
+| Home Assistant recorder | `recorder2scribe.py` | `RECORDER_*`, with `RECORDER_TYPE` set to `postgres` or `sqlite` (SQLite only needs `RECORDER_DB_PATH`) |
 
-1. Navigate to the `migration` directory:
-   ```bash
-   cd migration
-   ```
+Every run also needs `SCRIBE_*` — the destination — and the migration settings: `MIGRATION_START_TIME`, `MIGRATION_END_TIME`, `CHUNK_SIZE` (hours per batch), and `PURGE_DESTINATION`, which **deletes the destination's history before importing**. Leave it `False` unless you mean it.
 
-2. Install dependencies:
-   ```bash
-   pip install influxdb-client psycopg2-binary python-dotenv
-   ```
-
-3. Configure the migration:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Fill in [InfluxDB Configuration], [Scribe Configuration], and [Migration Settings]
-   ```
-
-4. Run the migration:
-   ```bash
-   python3 influx2scribe.py
-   ```
-
-
-### LTSS Migration
-
-#### Show LTSS Migration Guide
-
-1. Navigate to the `migration` directory:
-   ```bash
-   cd migration
-   ```
-
-2. Install dependencies:
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Configure the migration:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Fill in [LTSS Configuration], [Scribe Configuration], and [Migration Settings]
-   ```
-
-4. Run the migration:
-   ```bash
-   python3 ltss2scribe.py
-   ```
-
-
-### Recorder Migration
-
-#### Show Recorder Migration Guide
-
-1. Navigate to the `migration` directory:
-   ```bash
-   cd migration
-   ```
-
-2. Install dependencies:
-   ```bash
-   pip install psycopg2-binary python-dotenv
-   ```
-
-3. Configure the migration:
-   ```bash
-   cp .env.example .env
-   nano .env
-   # Fill in [Recorder Configuration], [Scribe Configuration], and [Migration Settings]
-   ```
-
-4. Run the migration:
-   ```bash
-   python3 recorder2scribe.py
-   ```
+Each script checks the destination schema before writing anything, and stops with an explanation rather than a wall of per-row errors if Scribe never initialised it.
 
 </details>
 
@@ -740,17 +650,7 @@ Please [open an issue](https://github.com/jonathan-gtd/scribe/issues) on GitHub 
 
 </details>
 
-<details>
-<summary><b>🔗 Related projects</b></summary>
-<br>
-
-Check out these related projects that work great with Scribe:
-
-- [Scribe Card](https://github.com/jonathan-gtd/scribe-card): the companion card — any query from your history, on a dashboard.
-- [timescale_database_reader](https://github.com/remmob/timescale_database_reader): A custom component to read data back from TimescaleDB into Home Assistant sensors.
-- [timescale-plotly-card](https://github.com/remmob/timescale-plotly-card): A highly customizable Plotly-based card for Home Assistant that can query TimescaleDB directly.
-
-</details>
+---
 
 ## License
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -1,0 +1,653 @@
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="brands_assets/dark_logo.png">
+  <img src="brands_assets/logo.png" alt="Scribe" width="300">
+</picture>
+
+### Home Assistant-historie in TimescaleDB
+
+Elke toestand en elke gebeurtenis, via `asyncpg` — zonder de event loop te blokkeren.
+
+[![Release](https://img.shields.io/github/v/release/jonathan-gtd/scribe?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases/latest) [![Downloads](https://img.shields.io/github/downloads/jonathan-gtd/scribe/total?color=41BDF5)](https://github.com/jonathan-gtd/scribe/releases) [![Tests](https://img.shields.io/github/actions/workflow/status/jonathan-gtd/scribe/tests.yaml?branch=master&label=tests)](https://github.com/jonathan-gtd/scribe/actions/workflows/tests.yaml) [![License](https://img.shields.io/github/license/jonathan-gtd/scribe?color=lightgrey)](LICENSE)
+
+[![lang en](https://img.shields.io/badge/lang-en-lightgrey)](README.md) [![lang fr](https://img.shields.io/badge/lang-fr-lightgrey)](README.fr.md) [![lang es](https://img.shields.io/badge/lang-es-lightgrey)](README.es.md) [![lang de](https://img.shields.io/badge/lang-de-lightgrey)](README.de.md) [![lang nl](https://img.shields.io/badge/lang-nl-41BDF5)](README.nl.md)
+
+</div>
+
+---
+
+De recorder van Home Assistant bewaart een paar weken historie in SQLite en wordt trager naarmate hij groeit. Scribe schrijft dezelfde toestanden en gebeurtenissen naar **TimescaleDB**, waar jaren snel blijven en een fractie van de ruimte innemen.
+
+- 🚀 **Van begin tot eind asynchroon** — `asyncpg` en gebundelde `COPY`: opnemen blokkeert Home Assistant nooit.
+- 🗜️ **Automatisch gecomprimeerd** — oude historie wordt in chunks gedeeld en gecomprimeerd, doorgaans 10× kleiner.
+- 🛟 **Er gaat niets verloren** — een database die plat ligt wordt gebufferd en geschreven zodra hij terug is.
+- 🧩 **Context inbegrepen** — entiteiten, apparaten, gebieden, gebruikers en integraties, niet alleen waarden.
+- 🩺 **Het zegt wanneer er iets mis is**, in Reparaties in plaats van in een log dat niemand leest.
+
+---
+
+## Installatie
+
+**1. Een TimescaleDB-database.** De extensie is verplicht — zie *TimescaleDB opzetten* hieronder.
+
+**2. Scribe, via HACS:**
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=jonathan-gtd&repository=scribe&category=integration)
+
+*Of met de hand:* kopieer `custom_components/scribe` naar uw map `custom_components`. Herstart daarna in beide gevallen Home Assistant.
+
+**3. De database-URL.** Ga naar **Instellingen → Apparaten en diensten → Integratie toevoegen**, zoek **Scribe** en plak hem:
+
+[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=scribe)
+
+```
+postgresql://scribe:password@192.168.1.10:5432/scribe
+```
+
+*Of in `configuration.yaml`*, als u uw configuratie liever in bestanden houdt:
+
+```yaml
+scribe:
+  db_url: "postgresql://scribe:password@192.168.1.10:5432/scribe"
+```
+
+Klaar — toestanden worden opgenomen, in chunks gedeeld en gecomprimeerd, met hun entiteit-, apparaat- en gebiedscontext. Al het onderstaande is optioneel.
+
+---
+
+<details>
+<summary><b>🧩 Scribe Card — grafieken op uw dashboard</b></summary>
+<br>
+
+**[Scribe Card](https://github.com/jonathan-gtd/scribe-card)** zet elke query uit uw historie op een dashboard. Getekend met Apache ECharts — waar de historiegrafieken van Home Assistant zelf ook op draaien — en ingesteld in een formulier, waarin het grafiektype, de eenheid en de assen worden gekozen uit de kolommen die uw query teruggeeft.
+
+Hij praat met Scribe via de dienst `scribe.query`, dus er is **geen tweede databaseverbinding om in te stellen en geen wachtwoord in uw dashboard**. Installeer hem via HACS als aangepaste repository, categorie *Dashboard*.
+
+</details>
+
+<details>
+<summary><b>🗄️ TimescaleDB opzetten</b></summary>
+<br>
+
+U hebt een draaiende TimescaleDB-instantie nodig. Ik raad PostgreSQL 17 of 18 aan.
+
+> **❗ Belangrijk** — **De TimescaleDB-extensie is verplicht.** Chunking, compressie, aanbewaring
+> en de groottesensoren zijn de hele reden van Scribe, en geen daarvan bestaat op
+> kale PostgreSQL. Een nieuwe installatie wordt geweigerd als de extensie ontbreekt —
+> al schakelt Scribe hem voor u in wanneer de server hem beschikbaar heeft en uw
+> databasegebruiker `CREATE` op de database heeft, wat de opzet hieronder toekent.
+> Installaties die al zonder draaien blijven opnemen en horen via een Reparatie
+> wat ze missen.
+
+#### Optie A: Home Assistant OS (add-on)
+
+Draait u Home Assistant OS, dan raad ik de [TimescaleDB-add-on](https://github.com/expaso/hassos-addon-timescaledb) aan.
+
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fexpaso%2Fhassos-addon-timescaledb)
+
+#### Optie B: Docker (handmatig)
+
+```bash
+# High Availability (aanbevolen)
+docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb-ha:pg18
+
+# Standaard
+docker run -d --name timescaledb -p 5432:5432 -e POSTGRES_PASSWORD=password timescale/timescaledb:pg18
+```
+
+Maak de database en de gebruiker aan:
+
+```sql
+CREATE DATABASE scribe;
+CREATE USER scribe WITH PASSWORD 'password';
+GRANT ALL PRIVILEGES ON DATABASE scribe TO scribe;
+
+\c scribe
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+GRANT ALL ON SCHEMA public TO scribe;
+```
+
+</details>
+
+<details>
+<summary><b>⚙️ Alle opties, met hun standaardwaarden</b></summary>
+<br>
+
+### Volledige configuratie (standaardwaarden)
+
+```yaml
+scribe:
+  # De enige verplichte optie.
+  db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
+
+  # Al het overige is optioneel. Dit zijn de standaardwaarden.
+
+  # Waar het schrijft
+  db_schema: ""                 # leeg = het schema van de verbinding, normaal public
+  db_ssl: false                 # TLS naar de database
+  ssl_root_cert: ""             # CA-certificaat; alleen gelezen als db_ssl true is
+  ssl_cert_file: ""             # clientcertificaat, voor wederzijdse TLS
+  ssl_key_file: ""              # de bijbehorende privésleutel
+
+  # Wat het opneemt
+  record_states: true           # toestandswijzigingen
+  record_events: false          # Home Assistant-gebeurtenissen (automatiseringen, scripts…)
+  include_domains: []           # leeg = alle domeinen
+  include_entities: []          # leeg = alle entiteiten
+  include_entity_globs: []      # bijv. sensor.weer_*
+  exclude_domains: []           # wordt na de include-lijsten toegepast
+  exclude_entities: []
+  exclude_entity_globs: []
+  exclude_attributes: []        # attributen die uit de kolom attributes worden gehaald
+  include_events: []            # leeg = alle gebeurtenistypen
+  exclude_events: []            # wordt na include_events toegepast
+
+  # Hoe lang het ze bewaart
+  chunk_time_interval: "7 days" # hoeveel tijd één chunk beslaat
+  compress_after: "7 days"      # chunks ouder dan dit worden gecomprimeerd
+  retention_states: ""          # leeg = voor altijd; anders VERWIJDERT het oudere toestanden
+  retention_events: ""          # leeg = voor altijd; anders VERWIJDERT het oudere gebeurtenissen
+  enable_rollups: false         # uur- en dagsamenvattingen van numerieke toestanden
+
+  # Hoe het schrijft
+  batch_size: 500               # rijen in de buffer vóór een schrijfactie
+  flush_interval: 5             # seconden voordat een onvolledige batch toch wordt geschreven
+  max_queue_size: 10000         # rijen in geheugen voordat nieuwe worden weggegooid
+  buffer_on_failure: true       # blijven bufferen zolang de database onbereikbaar is
+
+  # Wat scribe.query mag kosten
+  query_timeout: 60             # seconden dat een query mag draaien
+  query_max_rows: 20000         # rijen die hij mag teruggeven voordat hij wordt geweigerd
+
+  # Sensoren over Scribe zelf
+  enable_stats_io: false        # writer-tellers, uit het geheugen gelezen
+  enable_stats_chunk: false     # aantal chunks, één query per verversing
+  enable_stats_size: false      # schijfgrootte, één query per verversing
+  stats_io_interval: 60         # seconden tussen twee schrijfwaarden
+  stats_chunk_interval: 60      # minuten tussen twee chunk-queries
+  stats_size_interval: 60       # minuten tussen twee grootte-queries
+
+  # Contexttabellen, synchroon met de registers van Home Assistant
+  enable_table_areas: true
+  enable_table_devices: true
+  enable_table_integrations: true
+  enable_table_users: true
+```
+
+</details>
+
+<details>
+<summary><b>📋 Parameteroverzicht</b></summary>
+<br>
+
+| Parameter | Beschrijving |
+| :--- | :--- |
+| `db_url` | **Verplicht.** De verbindingsstring voor uw TimescaleDB-database. |
+| `db_ssl` | SSL/TLS inschakelen voor de databaseverbinding. |
+| `ssl_root_cert` | Pad naar het CA-certificaat (bijv. `/ssl/ca.crt`). Een relatief pad gaat uit van de configuratiemap van Home Assistant. |
+| `ssl_cert_file` | Pad naar het clientcertificaat, voor wederzijdse TLS. |
+| `ssl_key_file` | Pad naar de privésleutel van de client, voor wederzijdse TLS. |
+| `db_schema` | PostgreSQL-schema om in te schrijven. Leeg (standaard) gebruikt het schema van de verbinding zelf, normaal `public`. |
+| `chunk_time_interval` | Hoeveel tijd elke chunk van de tabel beslaat. Zie *Opslagafstemming* hieronder. |
+| `compress_after` | Chunks ouder dan dit worden gecomprimeerd. Zie *Opslagafstemming* hieronder. |
+| `retention_states` | **Verwijdert** toestandshistorie ouder dan dit interval (bijv. `"365 days"`). Leeg (standaard) bewaart alles. Zie *Aanbewaring* hieronder. |
+| `retention_events` | **Verwijdert** gebeurtenishistorie ouder dan dit interval. Leeg (standaard) bewaart alles. Zie *Aanbewaring* hieronder. |
+| `record_states` | Of toestandswijzigingen worden opgenomen. |
+| `record_events` | Of gebeurtenissen worden opgenomen. |
+| `batch_size` | Aantal items dat wordt gebufferd voordat naar de database wordt geschreven. |
+| `flush_interval` | Maximale tijd (in seconden) om te wachten voordat de buffer wordt weggeschreven. |
+| `max_queue_size` | Maximaal aantal items in geheugen voordat nieuwe worden weggegooid. |
+| `query_timeout` | Seconden dat een `scribe.query`-aanroep mag draaien voordat de database hem stopt (standaard `60`). |
+| `query_max_rows` | Rijen die een `scribe.query`-aanroep mag teruggeven voordat hij wordt geweigerd (standaard `20000`). |
+| `buffer_on_failure` | Zo ja, houdt data in geheugen als de database onbereikbaar is (tot `max_queue_size`). |
+| `enable_stats_io` | Realtime prestatiesensoren van de writer inschakelen (geen database-queries). |
+| `enable_stats_chunk` | Sensoren voor het aantal chunks inschakelen (bevraagt de database). |
+| `enable_stats_size` | Sensoren voor opslaggrootte inschakelen (bevraagt de database). |
+| `stats_io_interval` | Seconden tussen twee waarden van de schrijfsensoren (standaard `60`). Elke wijziging is een rij die Scribe over zichzelf opneemt. |
+| `stats_chunk_interval` | Interval (in minuten) om de chunkstatistieken bij te werken. |
+| `stats_size_interval` | Interval (in minuten) om de groottestatistieken bij te werken. |
+| `include_domains` | Lijst van domeinen om op te nemen. |
+| `include_entities` | Lijst van specifieke entiteiten om op te nemen. |
+| `include_entity_globs` | Lijst van entiteitspatronen om op te nemen (bijv. `sensor.weer_*`). |
+| `exclude_domains` | Lijst van domeinen om uit te sluiten. |
+| `exclude_entities` | Lijst van specifieke entiteiten om uit te sluiten. |
+| `exclude_entity_globs` | Lijst van entiteitspatronen om uit te sluiten (bijv. `switch.keuken_*`). |
+| `exclude_attributes` | Lijst van attributen om uit de kolom `attributes` te weren. |
+| `include_events` | Lijst van gebeurtenistypen om op te nemen. Leeg laten neemt alle gebeurtenissen op. |
+| `exclude_events` | Lijst van gebeurtenistypen die nooit worden opgenomen (na `include_events` toegepast). |
+| `enable_table_areas` | Aanmaken en synchroniseren van de tabel `areas` inschakelen. |
+| `enable_table_devices` | Aanmaken en synchroniseren van de tabel `devices` inschakelen. |
+| `enable_table_integrations` | Aanmaken en synchroniseren van de tabel `integrations` inschakelen. |
+| `enable_table_users` | Aanmaken en synchroniseren van de tabel `users` inschakelen. |
+| `enable_rollups` | Voorberekende uur- en dagsamenvattingen van toestanden bijhouden (`states_hourly`, `states_daily`). Standaard uit. |
+
+</details>
+
+<details>
+<summary><b>🗜️ Opslagafstemming — chunks en compressie</b></summary>
+<br>
+
+Scribe bewaart historie in **hypertables** van TimescaleDB: een tabel die eruitziet
+en bevraagd wordt als elke andere, maar fysiek is opgesplitst in **chunks**, elk
+voor een plak tijd. Vrijwel alles aan Scribes schijfgebruik en querysnelheid komt
+neer op die opsplitsing — een query over vorige week leest alleen de chunks die
+vorige week overlappen, compressie werkt chunk voor chunk, en *Aanbewaring*
+hieronder verwijdert hele chunks in plaats van losse rijen.
+
+Twee instellingen bepalen dat, zowel in YAML als in de interface onder
+**Configureren → Geavanceerd (TimescaleDB & SSL)**:
+
+### `chunk_time_interval` (standaard `7 days`)
+
+Hoeveel tijd één chunk beslaat.
+
+- **Kleinere chunks** (bijv. `1 day`) betekenen meer, kleinere bestanden: fijnmaziger
+  aanbewaring, en queries over korte recente vensters raken minder data. Voorbij een
+  bepaald punt moet een query over maanden honderden chunks openen.
+- **Grotere chunks** (bijv. `30 days`) betekenen minder, grotere bestanden: beter voor
+  lange historische queries, slechter voor geheugen — TimescaleDB adviseert zelf dat
+  de chunks waarin u schrijft samen met hun indexen comfortabel in het geheugen
+  passen, dus een te grote chunk op een kleine machine schaadt de schrijfprestaties.
+
+De standaard past bij een typische Home Assistant-installatie. Overweeg `1 day` als u
+duizenden entiteiten opneemt, en pas dan.
+
+> **Wijzigen raakt alleen nieuwe chunks.** Reeds geschreven chunks houden de spanne
+> waarmee ze zijn gemaakt, en er wordt niets herschreven of verplaatst — u krijgt
+> simpelweg een mengsel van oude en nieuwe spannes, waar TimescaleDB van nature mee omgaat.
+
+### `compress_after` (standaard `7 days`)
+
+Hoe oud een chunk moet zijn voordat TimescaleDB hem comprimeert. Compressie levert bij
+dit soort data doorgaans een forse verkleining op (veel herhaalde `entity_id`'s en
+langzaam veranderende waarden), en staat daarom standaard aan.
+
+Gecomprimeerde chunks blijven volledig bevraagbaar — de view `states` merkt er niets van.
+Erin *schrijven* is trager, en daarom slaat compressie pas toe zodra een chunk oud genoeg
+is om praktisch af te zijn. Houd `compress_after` ruim boven de leeftijd van de data waar
+u nog naartoe schrijft; toestanden die buiten volgorde binnenkomen (een backfill, een
+migratiescript) landen in oude chunks.
+
+> **Wijzigen gaat in bij de volgende herstart**, en al gecomprimeerde chunks blijven
+> gecomprimeerd — de instelling bepaalt alleen wanneer de *volgende* dat worden.
+
+### Hoe de drie instellingen samenhangen
+
+| Instelling | Wat het doet | Omkeerbaar |
+| :--- | :--- | :--- |
+| `chunk_time_interval` | Hoeveel tijd één chunk beslaat | Ja — alleen toekomstige chunks |
+| `compress_after` | Wanneer een chunk gecomprimeerd wordt | Ja |
+| `retention_states` / `retention_events` | Wanneer een chunk **verwijderd** wordt | **Nee** |
+
+Ze gelden in die volgorde voor dezelfde chunk gedurende zijn leven: geschreven →
+gecomprimeerd → weggegooid. Twee gevolgen zijn het waard te weten:
+
+- Is `compress_after` groter dan uw aanbewaring, dan worden chunks verwijderd voordat ze
+  ooit gecomprimeerd zijn, en doet compressie niets.
+- Aanbewaring verwijdert hele chunks, dus uw werkelijke bewaarvenster is het ingestelde
+  interval *plus* maximaal één `chunk_time_interval`. Kleinere chunks maken het strakker.
+
+Staan de sensoren voor grootte en chunks aan (`enable_stats_size`, `enable_stats_chunk`),
+dan rapporteren zij precies wat deze instellingen opleveren: aantallen chunks,
+gecomprimeerde en ongecomprimeerde groottes, en de compressieverhouding.
+
+</details>
+
+<details>
+<summary><b>🧹 Aanbewaring — oude historie volgens schema weggooien</b></summary>
+<br>
+
+Standaard bewaart Scribe alles, voor altijd. Wilt u slechts een begrensd venster opslaan
+— omdat u de ruwe historie elders samenvat, of eenvoudigweg om het schijfgebruik af te
+toppen — stel dan een bewaarinterval in, en TimescaleDB gooit chunks weg die ouder zijn:
+
+```yaml
+scribe:
+  db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
+  retention_states: "365 days"
+  retention_events: "30 days"
+```
+
+Beide staan ook in de interface onder **Configureren → Geavanceerd (TimescaleDB & SSL)**.
+
+> **⚠️ Let op** — Aanbewaring **verwijdert data definitief**. Er is geen ongedaan maken en geen
+> prullenbak: zodra een chunk buiten het venster valt wordt hij weggegooid, en alleen een
+> back-up brengt hem terug. Toestanden en gebeurtenissen worden apart ingesteld, zodat u
+> luidruchtige gebeurtenissen kunt laten verlopen terwijl u de toestandshistorie houdt.
+
+Het waard om te weten:
+
+- **Geen instelling betekent altijd "voor altijd bewaren".** Het veld in de interface legen
+  en de regel uit `configuration.yaml` halen verwijderen allebei het beleid — een waarde die
+  Scribe ooit uit YAML overnam mag nooit de regel overleven die hem zette.
+- **Scribe is eigenaar van het bewaarbeleid op zijn eigen tabellen.** Het veld legen verwijdert
+  het beleid — ook een dat u met de hand maakte via `add_retention_policy()`, wat de enige
+  manier is waarop het legen van de instelling de verwijderingen echt kan stoppen.
+- **Het begint meteen.** TimescaleDB draait het beleid binnen seconden na het aanmaken, niet
+  bij het volgende dagelijkse interval — alles buiten het venster is weg bij de eerste run,
+  vlak na de herstart die het inschakelde.
+- **Verwijderen gaat per chunk, niet per rij.** Een chunk wordt pas weggegooid als *alle* rijen
+  erin ouder zijn dan het interval, dus met de standaard `chunk_time_interval` van 7 dagen
+  houdt u tot een week meer dan u vroeg. Juist dat maakt aanbewaring bijna gratis: het gooit
+  bestanden weg in plaats van rijen te verwijderen.
+- **Alleen de historie wordt verwijderd.** De tabel `entities` en de andere metadatatabellen
+  worden niet aangeraakt, dus een entiteit waarvan de historie volledig verlopen is, blijft
+  oplosbaar.
+- **TimescaleDB is vereist** — het is de extensie die het beleid uitvoert. Op kale PostgreSQL
+  levert een bewaarinterval instellen een Reparatie op in plaats van stilletjes niets te doen.
+- Toegestane waarden zijn gewone intervallen: `30 days`, `6 months`, `1 year`. Al het andere
+  wordt met een foutmelding geweigerd in plaats van naar de database gestuurd.
+
+</details>
+
+<details>
+<summary><b>📈 Samenvattingen — uur- en dagaggregaten</b></summary>
+<br>
+
+Een jaar van een sensor die elke 30 seconden meldt, is ongeveer een miljoen rijen. Een grafiek van dat jaar leest ze allemaal, elke keer dat hij wordt getekend.
+
+Met `enable_rollups: true` houdt TimescaleDB twee samenvattingen van uw toestanden bij terwijl ze worden geschreven — per uur en per dag — en leest een grafiek over jaren duizenden rijen in plaats van miljoenen.
+
+```yaml
+scribe:
+  enable_rollups: true
+```
+
+Het staat ook in de interface onder **Configureren → Metadatatabellen**. Dat voegt twee views toe:
+
+| View | Eén rij per | Kolommen |
+| --- | --- | --- |
+| `states_hourly` | entiteit en uur | `entity_id`, `bucket`, `value_avg`, `value_min`, `value_max`, `samples` |
+| `states_daily` | entiteit en dag | dezelfde |
+
+```sql
+SELECT bucket, value_avg, value_min, value_max
+FROM states_daily
+WHERE entity_id = 'sensor.buitentemperatuur'
+  AND bucket > now() - interval '2 years'
+ORDER BY bucket;
+```
+
+Alleen numerieke toestanden worden samengevat — het gemiddelde van `on` en `off` betekent niets — dus `value_avg`, `value_min` en `value_max` blijven leeg voor de rest, terwijl `samples` elke toestand in de bucket telt.
+
+**Het zijn afgeleide gegevens.** Er wordt niets gedupliceerd dat u zou missen: de optie uitzetten verwijdert beide views, hem weer aanzetten bouwt ze opnieuw op uit de historie, en uw toestanden worden hoe dan ook nooit aangeraakt. TimescaleDB ververst ze zelf — die per uur elke 30 minuten, die per dag elk uur — en elke run kijkt ver genoeg terug (3 dagen, 30 dagen) dat een laat geschreven batch er alsnog in landt. Scribe maakt ze alleen aan.
+
+</details>
+
+<details>
+<summary><b>🗃️ Naar een specifiek PostgreSQL-schema schrijven</b></summary>
+<br>
+
+Standaard schrijft Scribe naar het schema waar uw verbinding toch al naar wijst — normaal `public`. Zet `db_schema` en het maakt dat schema aan en zet er alles in: zijn tabellen, zijn views, zijn hypertables en zijn beleidsregels.
+
+```yaml
+scribe:
+  db_url: postgresql://scribe:password@192.168.1.10:5432/scribe
+  db_schema: scribe
+```
+
+Het staat ook in de interface onder **Configureren → Geavanceerd (TimescaleDB & SSL)**.
+
+Dit wilt u wanneer Scribe een database deelt met iets anders: de tabellen van een andere integratie, uw eigen kopieën van de historie, of een tweede Home Assistant die naar dezelfde server schrijft. Schema's zijn onafhankelijk — eigen tabellen, hypertables, aanbewaring en compressie — en niets van wat Scribe in het ene doet, raakt het andere.
+
+- **Alleen nieuwe data gaat erheen.** `db_schema` zetten verplaatst reeds opgenomen historie niet. Verplaats die zelf vóór de herstart (`ALTER TABLE public.states_raw SET SCHEMA scribe;`), of bevraag het oude schema rechtstreeks.
+- **Scribe maakt het schema aan als het mag**, waarvoor `CREATE` op de database nodig is. Een schema dat u met de hand maakte werkt ook, mits `USAGE` en `CREATE` erop.
+- **Een onbereikbaar schema stopt het opnemen.** PostgreSQL valt terug op het volgende item van het search path in plaats van te falen, dus een typefout zou anders `public` vullen terwijl de interface iets anders toont. Scribe controleert waar het geland is en schrijft liever niets dan op de verkeerde plek, met een Reparatie die zegt wat er toegekend moet worden.
+- **Uw queries veranderen niet.** Scribe zet het schema vooraan in het `search_path` van de verbinding, dus `SELECT * FROM states` blijft werken via `scribe.query`. Vanuit Grafana of psql kwalificeert u de naam (`scribe.states`) of zet u uw eigen `search_path`. `public` blijft op het pad — daar wonen de TimescaleDB-functies.
+- Toegestane waarden zijn gewone identifiers: letters, cijfers en underscores, niet beginnend met een cijfer. Leeg behoudt het schema van de verbinding zelf, ook een dat u zelf met `?options=-csearch_path%3Dmijnschema` in de URL hebt gezet.
+
+**De tabellen zelf** — elke kolom, hoe ze samenhangen, en queryrecepten voor Grafana en `scribe.query` — staan beschreven in [`docs/data-structure.md`](docs/data-structure.md).
+
+</details>
+
+<details>
+<summary><b>🛠️ Diensten — flush, query, purge</b></summary>
+<br>
+
+### `scribe.flush`
+Forceer het onmiddellijk wegschrijven van gebufferde data naar de database.
+
+```yaml
+service: scribe.flush
+```
+
+### `scribe.query`
+Voer een alleen-lezen SQL-query uit op de TimescaleDB-database.
+
+**Parameters:**
+- `sql` (verplicht): de uit te voeren SQL-query. Moet een `SELECT` zijn.
+
+**Geeft terug:**
+Een lijst met rijen, waarbij elke rij een woordenboek is van kolomnamen en waarden.
+
+**Voorbeeld:**
+```yaml
+service: scribe.query
+data:
+  sql: "SELECT * FROM states ORDER BY time DESC LIMIT 5"
+response_variable: query_result
+```
+
+### `scribe.purge`
+Verwijder opgenomen historie. **Dit kan niet ongedaan worden gemaakt.**
+
+**Parameters** (ten minste een van de eerste twee is verplicht):
+- `entity_id`: entiteiten om op te schonen. Zonder `keep_days` worden hun hele historie *en* hun rij in de tabel `entities` verwijderd — ze opnieuw opnemen begint dan vanaf niets.
+- `keep_days`: verwijder alles ouder dan dit aantal dagen.
+- `events` (standaard `false`): verwijder ook gebeurtenissen ouder dan `keep_days`. Zonder dat genegeerd.
+
+**Geeft terug:** hoeveel toestanden, gebeurtenissen en entiteitsrijen zijn verwijderd.
+
+**Voorbeelden:**
+```yaml
+# Eén entiteit volledig uit de database halen
+action: scribe.purge
+data:
+  entity_id: sensor.sensor_die_ik_niet_meer_wil
+```
+
+```yaml
+# Alles ouder dan twee jaar inkorten, gebeurtenissen inbegrepen
+action: scribe.purge
+data:
+  keep_days: 730
+  events: true
+response_variable: purged
+```
+
+Gecomprimeerde historie wordt ook opgeschoond; TimescaleDB regelt dat, en de chunks blijven gecomprimeerd. Voor een doorlopend venster dat u wilt blijven toepassen, gebruikt u in plaats daarvan de instellingen onder *Aanbewaring* hieronder: een purge is eenmalig.
+
+</details>
+
+<details>
+<summary><b>📊 Statistieksensoren</b></summary>
+<br>
+
+Sensoren schakelt u in met hun vlaggen in uw configuratie.
+
+### Schrijfstatistieken (`enable_stats_io: true`)
+
+Realtime metingen uit de writer (geen database-queries).
+
+| Sensor | Beschrijving |
+| :--- | :--- |
+| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_states_written` | Totaal aantal toestandswijzigingen dat naar de database is geschreven. |
+| <img src="https://api.iconify.design/mdi:database-plus.svg?color=%232196F3" width="15" /> `sensor.scribe_events_written` | Totaal aantal gebeurtenissen dat naar de database is geschreven. |
+| <img src="https://api.iconify.design/mdi:buffer.svg?color=%232196F3" width="15" /> `sensor.scribe_buffer_size` | Huidig aantal items dat in de geheugenbuffer wacht. |
+| <img src="https://api.iconify.design/mdi:timer-sand.svg?color=%232196F3" width="15" /> `sensor.scribe_last_write_duration` | Duur (in ms) van de laatste schrijfactie naar de database. |
+| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_states_rate` | Snelheid van naar de database geschreven toestanden (per minuut). |
+| <img src="https://api.iconify.design/mdi:speedometer.svg?color=%232196F3" width="15" /> `sensor.scribe_events_rate` | Snelheid van naar de database geschreven gebeurtenissen (per minuut). |
+
+### Chunkstatistieken (`enable_stats_chunk: true`)
+
+Aantallen chunks (bijgewerkt elke `stats_chunk_interval` minuten).
+
+| Sensor | Beschrijving |
+| :--- | :--- |
+| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_chunks` | Totaal aantal chunks voor de tabel states. |
+| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_chunks` | Aantal chunks dat gecomprimeerd is. |
+| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_chunks` | Aantal chunks dat op compressie wacht. |
+| <img src="https://api.iconify.design/mdi:cube-outline.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_chunks` | Totaal aantal chunks voor de tabel events. |
+| <img src="https://api.iconify.design/mdi:package-down.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_chunks` | Aantal gecomprimeerde gebeurtenis-chunks. |
+| <img src="https://api.iconify.design/mdi:package-up.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_chunks` | Aantal ongecomprimeerde gebeurtenis-chunks. |
+
+### Groottestatistieken (`enable_stats_size: true`)
+
+Opslaggebruik in bytes (bijgewerkt elke `stats_size_interval` minuten).
+
+| Sensor | Beschrijving |
+| :--- | :--- |
+| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_states_total_size` | Totale schijfgrootte (inclusief gecomprimeerde data + recente chunks + indexen). |
+| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_states_original_size` | **Theoretische grootte** als de data niet gecomprimeerd was (bijv. 11 GB). |
+| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compressed_size` | Fysieke grootte van de gecomprimeerde datachunks. |
+| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_states_uncompressed_size` | Grootte van recente data die nog niet gecomprimeerd is (of indexen in afwachting). |
+| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_states_compression_ratio` | Compressieverhouding voor toestanden (%). |
+| <img src="https://api.iconify.design/mdi:database.svg?color=%232196F3" width="15" /> `sensor.scribe_events_total_size` | Totale schijfgrootte van de tabel events. |
+| <img src="https://api.iconify.design/mdi:database-search.svg?color=%232196F3" width="15" /> `sensor.scribe_events_original_size` | Theoretische grootte van gebeurtenissen vóór compressie. |
+| <img src="https://api.iconify.design/mdi:package-variant.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compressed_size` | Grootte van gecomprimeerde gebeurtenisdata. |
+| <img src="https://api.iconify.design/mdi:package-variant-closed.svg?color=%232196F3" width="15" /> `sensor.scribe_events_uncompressed_size` | Grootte van ongecomprimeerde gebeurtenisdata. |
+| <img src="https://api.iconify.design/mdi:percent.svg?color=%232196F3" width="15" /> `sensor.scribe_events_compression_ratio` | Compressieverhouding voor gebeurtenissen (%). |
+
+</details>
+
+<details>
+<summary><b>🖼️ Dashboard</b></summary>
+<br>
+
+Een kant-en-klare Lovelace-indeling met alle nuttige Scribe-sensoren (databasestatistieken, compressieverhoudingen, schrijfprestaties) staat in deze repository, in twee smaken:
+
+| Bestand | Wat het is | Waar u het plakt |
+| --- | --- | --- |
+| [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml) | Eén **enkele kaart** (`type: vertical-stack`) | De YAML-editor van de kaart ("Kaart toevoegen" → "Handmatig") |
+| [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml) | Een **hele weergave** (`title` / `icon` / `cards`) | De YAML-editor van de weergave |
+
+> ⚠️ Deze twee zijn niet uitwisselbaar. Het *weergave*-bestand in een *kaart*-editor plakken mislukt met **"No card type configured"**, omdat een kaartconfiguratie met een `type:`-sleutel moet beginnen.
+
+**Optie A — als kaart toevoegen (eenvoudigst, werkt in elk weergavetype):**
+
+1.  Open uw dashboard en klik op "Dashboard bewerken" (potloodpictogram).
+2.  Klik op **+ Kaart toevoegen** en scroll naar de onderkant van de kaartkiezer om **Handmatig** te kiezen.
+3.  Kopieer de inhoud van [`lovelace_scribe_card.yaml`](lovelace_scribe_card.yaml), vervang alles in de editor ermee, en klik op **Opslaan**.
+
+**Optie B — als eigen weergave toevoegen:**
+
+1.  Open uw dashboard en klik op "Dashboard bewerken" (potloodpictogram).
+2.  Klik op de knop **+** *in de tabbalk bovenaan* (naast uw bestaande weergavenamen) om een nieuwe weergave toe te voegen — niet op "Kaart toevoegen".
+3.  Open in het weergavevenster het menu ⋮ (of de knop "Code-editor weergeven") en kies **In YAML bewerken**.
+4.  Kopieer de inhoud van [`lovelace_scribe_view.yaml`](lovelace_scribe_view.yaml), vervang alles in de editor ermee, en klik op **Opslaan**.
+
+</details>
+
+<details>
+<summary><b>📦 Migreren vanaf InfluxDB, LTSS, de recorder of Scribe 2.x</b></summary>
+<br>
+
+### Bijwerken vanaf Scribe 2.x
+
+Scribe 3.0 verving de tabel `states` door `states_raw` plus een compatibiliteitsview, en
+gaf `entities` een numerieke primaire sleutel. De omzetting van een oude database werd
+door 3.x gedaan en is **in 3.9 verwijderd**.
+
+Heeft uw database nog een `states`-*tabel* (in plaats van een view), een tabel
+`states_legacy`, of een tabel `entities` zonder kolom `id`, dan stopt Scribe bij het
+starten, neemt niets op en meldt een Reparatie — zonder iets te hernoemen, aan te maken
+of te verwijderen. Installeer **Scribe 3.8**, laat Home Assistant draaien tot de logs
+melden dat de migratie klaar is (ongeveer een kwartier op een grote database), en werk
+daarna opnieuw bij.
+
+Nieuwe installaties en elke door 3.x gemaakte database hebben hier geen last van.
+
+### Data uit andere bronnen overnemen
+
+In `migration/` staan drie scripts die historie van elders naar Scribe kopiëren. Ze worden eenmalig met de hand gedraaid, vanaf een machine die beide databases bereikt — en Scribe moet minstens één keer gestart zijn, zodat zijn tabellen bestaan.
+
+```bash
+cd migration
+pip install psycopg2-binary python-dotenv   # voor InfluxDB daarnaast influxdb-client
+cp .env.example .env && nano .env
+python3 <script>.py
+```
+
+| Bron | Script | In te vullen |
+| --- | --- | --- |
+| InfluxDB | `influx2scribe.py` | `INFLUX_*` |
+| LTSS | `ltss2scribe.py` | `LTSS_*` |
+| Home Assistant-recorder | `recorder2scribe.py` | `RECORDER_*`, met `RECORDER_TYPE` op `postgres` of `sqlite` (SQLite heeft alleen `RECORDER_DB_PATH` nodig) |
+
+Elke run heeft daarnaast `SCRIBE_*` nodig — de bestemming — en de migratie-instellingen: `MIGRATION_START_TIME`, `MIGRATION_END_TIME`, `CHUNK_SIZE` (uren per batch) en `PURGE_DESTINATION`, dat **de historie van de bestemming wist vóór het importeren**. Laat het op `False` staan tenzij u het echt bedoelt.
+
+Elk script controleert het bestemmingsschema voordat het iets schrijft, en stopt met een uitleg in plaats van een muur aan fouten rij voor rij als Scribe het nooit heeft geïnitialiseerd.
+
+</details>
+
+<details>
+<summary><b>🩺 Probleemoplossing</b></summary>
+<br>
+
+### Eerst dit
+
+Twee plekken beantwoorden "waarom wordt er niets opgenomen?" zonder ook maar één logregel te lezen:
+
+- **Instellingen → Apparaten en diensten → Scribe → ⋮ → Diagnose downloaden** meldt wat de
+  writer werkelijk doet: verbonden of niet, of TimescaleDB gevonden is, hoeveel items in de
+  buffer wachten en hoeveel er zijn weggegooid, opeenvolgende schrijffouten, en de geldende
+  opslag- en bewaarinstellingen. De database-URL zit er nooit in, en uit driverfouten wordt
+  elke verbindingsstring gestript.
+- **Instellingen → Systeem → Reparaties** somt de onderstaande situaties op, en
+  **Instellingen → Systeem → Systeemstatus** toont op welke database Scribe is gericht en of
+  hij op dit moment verbonden is.
+
+### Reparaties
+
+Scribe meldt problemen die het niet zelf kan oplossen in **Instellingen → Systeem → Reparaties**, zodat u de logs niet hoeft te bewaken. Elke melding verdwijnt vanzelf zodra de situatie is opgelost.
+
+| Reparatie | Wat het betekent |
+| --- | --- |
+| Kan de database niet bereiken | De verbinding is mislukt. Scribe blijft bufferen en probeert het op de achtergrond opnieuw, dus historie uit de storing wordt geschreven zodra de database terug is. Controleer of de server draait en of URL en inloggegevens kloppen. |
+| Kan niet naar de database schrijven | Meerdere schrijfacties achter elkaar zijn mislukt. Data staat in geheugen en wordt bij herstel weggeschreven — tenzij Home Assistant eerst herstart. |
+| Buffer is vol | De schrijfacties mislukten lang genoeg om de buffer te verzadigen; de oudste records worden nu weggegooid. Herstel de database, of verhoog `max_queue_size`. |
+| Records worden weggegooid | Een schrijfactie mislukte terwijl bufferen uitstaat, dus records zijn meteen weggegooid. Zet bufferen aan om korte storingen te overleven. |
+| Kon zijn tabellen niet aanmaken | Scribe bereikte de database maar kon zijn schema niet bouwen, meestal een rechtenprobleem. Op een nieuwe database wordt er helemaal niets opgenomen. |
+| Kan het opgegeven schema niet bereiken | Het schema in `db_schema` bestaat niet en kon niet worden aangemaakt, of de databasegebruiker heeft er geen rechten op. Er wordt niets opgenomen — in plaats van stilletjes `public` te vullen. |
+| Kon de view `states` niet aanmaken | Historie wordt opgenomen, maar de view waar elke query doorheen gaat ontbreekt — de historie lijkt leeg terwijl er niets verloren is. |
+| `states_raw` / `events` is geen hypertable | TimescaleDB is geïnstalleerd maar de tabel is nooit omgezet (gebruikelijk wanneer de extensie *na* het vollopen van de tabellen is toegevoegd). Chunking, compressie en aanbewaring doen dan niets. |
+| `states_raw` / `events` wordt nooit gecomprimeerd | De tabel is een hypertable maar heeft geen compressiebeleid, en houdt dus zijn volle ongecomprimeerde grootte. |
+| TLS geldt niet volledig | Scribe verbindt via TLS, maar een door u ingesteld certificaat kon niet worden toegepast — meestal een clientcertificaat, waardoor het zich als gewone client aanmeldt in plaats van als degene die u voorzag. |
+| TimescaleDB is niet geïnstalleerd | Historie wordt opgenomen, maar chunking en compressie zijn niet beschikbaar, dus de database groeit veel sneller en de groottesensoren blijven leeg. |
+| Database dateert van vóór versie 3.0 | De database gebruikt nog de indeling van vóór 3.0, die deze versie niet kan omzetten. Er wordt niets opgenomen en er is niets gewijzigd — installeer Scribe 3.8 om hem om te zetten, en werk daarna opnieuw bij. |
+| Kon het bewaarbeleid niet toepassen | U vroeg Scribe data ouder dan een interval te verwijderen en het beleid kon niet worden aangemaakt. Er is niets verwijderd, en er wordt niets verwijderd — de tabel blijft groeien. |
+| Hernoemen van entiteit niet toegepast | Een hernoeming botste met een bestaande rij in de database. De historie van de entiteit staat verdeeld over de twee ID's. |
+
+### Hoog geheugengebruik
+- Verlaag `max_queue_size`
+- Verlaag `flush_interval` voor sneller schrijven
+- Controleer `sensor.scribe_buffer_size`
+
+### Prestatieafstemming
+
+Is de view `states` traag (meerdere seconden per query), dan komt dat waarschijnlijk doordat de queryplanner van PostgreSQL een **Hash Join** kiest in plaats van een **Nested Loop**, waardoor TimescaleDB chunks niet effectief kan wegsnoeien.
+
+De meest voorkomende oorzaak is een hoge `random_page_cost` (standaard `4.0`, geoptimaliseerd voor harde schijven). Gebruikt u moderne opslag (SSD, NVMe) of is uw database goed gecachet, verlaag die waarde dan:
+
+```sql
+-- Huidige waarde bekijken
+SHOW random_page_cost;
+
+-- Op een lagere waarde zetten (meestal 1.1)
+ALTER SYSTEM SET random_page_cost = 1.1;
+SELECT pg_reload_conf();
+```
+
+Die waarde verlagen moedigt de planner aan om index-gebaseerde joins (Nested Loops) te gebruiken, die essentieel zijn voor Scribes prestaties bij grote datasets.
+
+### Nog steeds problemen?
+[Open een issue](https://github.com/jonathan-gtd/scribe/issues) op GitHub met uw logs en configuratie. Ik help graag!
+
+</details>
+
+---
+
+## Licentie
+
+MIT-licentie — zie het bestand LICENSE voor details

--- a/custom_components/scribe/translations/nl.json
+++ b/custom_components/scribe/translations/nl.json
@@ -1,123 +1,214 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "title": "Verbinden met TimescaleDB",
-                "description": "Voer de PostgreSQL-verbindings-URL in voor uw TimescaleDB-instantie.\n\nFormaat: `postgresql://gebruiker:wachtwoord@host:5432/dbname`\n\nExtra opties (SSL, filtering, chunk-intervallen) zijn beschikbaar na installatie via **Configureren**.",
-                "data": {
-                    "db_url": "Database URL"
-                },
-                "data_description": {
-                    "db_url": "Volledige PostgreSQL-verbindings-URL, bijv. postgresql://scribe:geheim@192.168.1.10:5432/scribe"
-                }
-            }
+  "config": {
+    "step": {
+      "user": {
+        "title": "Verbinden met TimescaleDB",
+        "description": "Voer de PostgreSQL-verbindings-URL in voor uw TimescaleDB-instantie.\n\nFormaat: `postgresql://gebruiker:wachtwoord@host:5432/dbname`\n\nExtra opties (SSL, filtering, chunk-intervallen) zijn beschikbaar na installatie via **Configureren**.",
+        "data": {
+          "db_url": "Database-URL"
         },
-        "error": {
-            "cannot_connect": "Kan geen verbinding maken met de database. Controleer de URL en zorg ervoor dat PostgreSQL bereikbaar is."
-        },
-        "abort": {
-            "already_configured": "Scribe is al geconfigureerd. Gebruik **Configureren** om instellingen te wijzigen.",
-            "single_instance_allowed": "Slechts één Scribe-instantie is toegestaan."
+        "data_description": {
+          "db_url": "Volledige PostgreSQL-verbindings-URL, bijv. postgresql://scribe:geheim@192.168.1.10:5432/scribe"
         }
+      }
     },
-    "options": {
-        "step": {
-            "init": {
-                "title": "Opname & Filtering",
-                "data": {
-                    "record_states": "Statusveranderingen opnemen",
-                    "record_events": "Gebeurtenissen opnemen",
-                    "include_domains": "Domeinen opnemen",
-                    "exclude_domains": "Domeinen uitsluiten",
-                    "include_entities": "Entiteiten opnemen",
-                    "exclude_entities": "Entiteiten uitsluiten",
-                    "include_entity_globs": "Entiteitspatronen opnemen",
-                    "exclude_entity_globs": "Entiteitspatronen uitsluiten",
-                    "exclude_attributes": "Attributen uitsluiten",
-                    "include_events": "Gebeurtenistypen opnemen"
-                },
-                "data_description": {
-                    "record_states": "Write every state change to TimescaleDB",
-                    "record_events": "Write Home Assistant events to TimescaleDB",
-                    "include_domains": "Only record entities from these domains.",
-                    "exclude_domains": "Never record entities from these domains",
-                    "include_entities": "Only record these specific entities.",
-                    "exclude_entities": "Never record these specific entities",
-                    "include_entity_globs": "Only record entities matching these patterns",
-                    "exclude_entity_globs": "Never record entities matching these patterns",
-                    "exclude_attributes": "Drop these attribute keys before writing",
-                    "include_events": "Only record these specific event types. Leave empty to record all events."
-                }
-            },
-            "performance": {
-                "title": "Prestaties",
-                "data": {
-                    "batch_size": "Batchgrootte",
-                    "flush_interval": "Verzendinterval (seconden)",
-                    "max_queue_size": "Maximale wachtrijgrootte",
-                    "buffer_on_failure": "Bufferen bij fouten"
-                },
-                "data_description": {
-                    "batch_size": "Number of rows accumulated before a flush is triggered",
-                    "flush_interval": "Maximum seconds between automatic flushes",
-                    "max_queue_size": "Maximum pending writes before oldest are dropped",
-                    "buffer_on_failure": "Keep events in memory and retry when the database becomes available again"
-                }
-            },
-            "stats": {
-                "title": "Statistieksensoren",
-                "data": {
-                    "enable_stats_io": "I/O-statistieksensoren inschakelen",
-                    "enable_stats_chunk": "Chunk-statistieksensoren inschakelen",
-                    "stats_chunk_interval": "Refresh interval",
-                    "enable_stats_size": "Grootte-statistieksensoren inschakelen",
-                    "stats_size_interval": "Refresh interval"
-                },
-                "data_description": {
-                    "enable_stats_io": "Expose write counters, buffer size and duration as sensors",
-                    "enable_stats_chunk": "Expose per-table chunk counts",
-                    "stats_chunk_interval": "How often stats are refreshed from the database",
-                    "enable_stats_size": "Expose per-table sizes and compression ratios",
-                    "stats_size_interval": "How often stats are refreshed from the database"
-                }
-            },
-            "metadata": {
-                "title": "Metadatatabellen",
-                "data": {
-                    "enable_table_areas": "Sync areas table",
-                    "enable_table_devices": "Sync devices table",
-                    "enable_table_integrations": "Sync integrations table",
-                    "enable_table_users": "Sync users table"
-                },
-                "data_description": {
-                    "enable_table_areas": "Keep a mirror of HA areas in TimescaleDB",
-                    "enable_table_devices": "Keep a mirror of HA devices in TimescaleDB",
-                    "enable_table_integrations": "Keep a mirror of integrations in TimescaleDB",
-                    "enable_table_users": "Keep a mirror of HA users in TimescaleDB"
-                }
-            },
-            "advanced": {
-                "title": "Geavanceerd (TimescaleDB & SSL)",
-                "data": {
-                    "chunk_time_interval": "Chunk time interval",
-                    "compress_after": "Compress after",
-                    "db_ssl": "Enable SSL",
-                    "ssl_root_cert": "SSL root certificate path",
-                    "ssl_cert_file": "SSL client certificate path",
-                    "ssl_key_file": "SSL client key path"
-                },
-                "data_description": {
-                    "chunk_time_interval": "TimescaleDB chunk interval",
-                    "compress_after": "Compress chunks older than this interval",
-                    "db_ssl": "Require an SSL/TLS connection",
-                    "ssl_root_cert": "Path to the CA certificate file",
-                    "ssl_cert_file": "Path to the client certificate file",
-                    "ssl_key_file": "Path to the client private key file"
-                }
-            }
-        },
-        "error": {
-            "must_record_something": "Ten minste één van 'Statusveranderingen opnemen' of 'Gebeurtenissen opnemen' moet zijn ingeschakeld."
-        }
+    "error": {
+      "cannot_connect": "Kan geen verbinding maken met de database. Controleer de URL en zorg ervoor dat PostgreSQL bereikbaar is.",
+      "no_timescaledb": "Verbonden, maar deze database heeft geen TimescaleDB-extensie en Scribe kon hem niet inschakelen. Scribe is een TimescaleDB-integratie: zonder de extensie is er geen chunking, geen compressie en geen aanbewaring, en groeit de database enkele malen sneller. Voer `CREATE EXTENSION timescaledb;` uit op deze database (de gebruiker heeft er CREATE op nodig), of wijs Scribe naar een TimescaleDB-instantie."
+    },
+    "abort": {
+      "already_configured": "Scribe is al geconfigureerd. Gebruik **Configureren** om instellingen te wijzigen.",
+      "single_instance_allowed": "Slechts één Scribe-instantie is toegestaan.",
+      "no_timescaledb": "Deze database heeft geen TimescaleDB-extensie en Scribe kon hem niet inschakelen, dus de installatie is geweigerd. Voer er `CREATE EXTENSION timescaledb;` op uit en herstart daarna Home Assistant."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opname & Filtering",
+        "data": {
+          "record_states": "Statusveranderingen opnemen",
+          "record_events": "Gebeurtenissen opnemen",
+          "include_domains": "Domeinen opnemen",
+          "exclude_domains": "Domeinen uitsluiten",
+          "include_entities": "Entiteiten opnemen",
+          "exclude_entities": "Entiteiten uitsluiten",
+          "include_entity_globs": "Entiteitspatronen opnemen",
+          "exclude_entity_globs": "Entiteitspatronen uitsluiten",
+          "exclude_attributes": "Attributen uitsluiten",
+          "include_events": "Gebeurtenistypen opnemen",
+          "exclude_events": "Gebeurtenistypen uitsluiten"
+        },
+        "data_description": {
+          "record_states": "Elke toestandswijziging naar TimescaleDB schrijven",
+          "record_events": "Write Home Assistant events to TimescaleDB",
+          "include_domains": "Only record entities from these domains.",
+          "exclude_domains": "Entiteiten uit deze domeinen nooit opnemen",
+          "include_entities": "Only record these specific entities.",
+          "exclude_entities": "Deze specifieke entiteiten nooit opnemen",
+          "include_entity_globs": "Only record entities matching these patterns",
+          "exclude_entity_globs": "Entiteiten die op deze patronen passen nooit opnemen",
+          "exclude_attributes": "Drop these attribute keys before writing",
+          "include_events": "Alleen deze specifieke gebeurtenistypen opnemen. Leeg laten neemt alle gebeurtenissen op.",
+          "exclude_events": "Deze gebeurtenistypen nooit opnemen (na include_events toegepast)."
+        }
+      },
+      "performance": {
+        "title": "Prestaties",
+        "data": {
+          "batch_size": "Batchgrootte",
+          "flush_interval": "Verzendinterval (seconden)",
+          "max_queue_size": "Maximale wachtrijgrootte",
+          "buffer_on_failure": "Bufferen bij fouten"
+        },
+        "data_description": {
+          "batch_size": "Number of rows accumulated before a flush is triggered",
+          "flush_interval": "Maximum seconds between automatic flushes",
+          "max_queue_size": "Maximum pending writes before oldest are dropped",
+          "buffer_on_failure": "Gebeurtenissen in geheugen houden en opnieuw proberen zodra de database weer beschikbaar is"
+        }
+      },
+      "stats": {
+        "title": "Statistieksensoren",
+        "data": {
+          "enable_stats_io": "I/O-statistieksensoren inschakelen",
+          "enable_stats_chunk": "Chunk-statistieksensoren inschakelen",
+          "stats_chunk_interval": "Refresh interval",
+          "enable_stats_size": "Grootte-statistieksensoren inschakelen",
+          "stats_size_interval": "Refresh interval",
+          "stats_io_interval": "Hoe vaak de schrijfsensoren publiceren"
+        },
+        "data_description": {
+          "enable_stats_io": "Expose write counters, buffer size and duration as sensors",
+          "enable_stats_chunk": "Expose per-table chunk counts",
+          "stats_chunk_interval": "How often stats are refreshed from the database",
+          "enable_stats_size": "Expose per-table sizes and compression ratios",
+          "stats_size_interval": "How often stats are refreshed from the database",
+          "stats_io_interval": "Seconden tussen twee waarden van de schrijfsensoren. Elke wijziging is een rij die Scribe over zichzelf opneemt, dus een kort interval vult uw historie met Scribes eigen tellers. Standaard 60 seconden."
+        }
+      },
+      "metadata": {
+        "title": "Metadatatabellen",
+        "data": {
+          "enable_table_areas": "Tabel areas synchroniseren",
+          "enable_table_devices": "Tabel devices synchroniseren",
+          "enable_table_integrations": "Tabel integrations synchroniseren",
+          "enable_table_users": "Tabel users synchroniseren",
+          "enable_rollups": "Uur- en dagsamenvattingen"
+        },
+        "data_description": {
+          "enable_table_areas": "Keep a mirror of HA areas in TimescaleDB",
+          "enable_table_devices": "Keep a mirror of HA devices in TimescaleDB",
+          "enable_table_integrations": "Keep a mirror of integrations in TimescaleDB",
+          "enable_table_users": "Keep a mirror of HA users in TimescaleDB",
+          "enable_rollups": "Houd voorberekende uur- en daggemiddelden van uw toestanden bij, onderhouden door TimescaleDB. Grafieken over maanden of jaren lezen dan duizenden rijen in plaats van miljoenen. Voegt de views states_hourly en states_daily toe."
+        }
+      },
+      "advanced": {
+        "title": "Geavanceerd (TimescaleDB & SSL)",
+        "data": {
+          "db_schema": "Databaseschema",
+          "chunk_time_interval": "Tijdsinterval per chunk",
+          "compress_after": "Comprimeren na",
+          "retention_states": "Toestanden verwijderen ouder dan",
+          "retention_events": "Gebeurtenissen verwijderen ouder dan",
+          "db_ssl": "SSL inschakelen",
+          "ssl_root_cert": "Pad naar SSL-hoofdcertificaat",
+          "ssl_cert_file": "Pad naar SSL-clientcertificaat",
+          "ssl_key_file": "Pad naar SSL-clientsleutel",
+          "query_timeout": "Querytime-out",
+          "query_max_rows": "Maximaal aantal rijen per query"
+        },
+        "data_description": {
+          "db_schema": "Leeg laten gebruikt waar de verbinding al naar wijst (normaal `public`). Vul een naam in en Scribe maakt dat schema aan en schrijft erin — zijn tabellen, zijn hypertables, zijn beleidsregels. Alleen nieuwe data gaat erheen: historie die elders al geschreven is, wordt niet verplaatst, en Scribe neemt helemaal niets op als het schema onbereikbaar is.",
+          "chunk_time_interval": "TimescaleDB chunk interval",
+          "compress_after": "Compress chunks older than this interval",
+          "retention_states": "Leeg laten bewaart elke toestand voor altijd (standaard). Stel een interval in (bijv. '365 days', '6 months') en TimescaleDB VERWIJDERT toestandshistorie die ouder is — definitief, zonder ongedaan maken. Scribe is eigenaar van dit beleid: het veld legen verwijdert het.",
+          "retention_events": "Leeg laten bewaart elke gebeurtenis voor altijd (standaard). Stel een interval in (bijv. '30 days') en TimescaleDB VERWIJDERT gebeurtenishistorie die ouder is — definitief, zonder ongedaan maken. Scribe is eigenaar van dit beleid: het veld legen verwijdert het.",
+          "db_ssl": "Require an SSL/TLS connection",
+          "ssl_root_cert": "Path to the CA certificate file",
+          "ssl_cert_file": "Path to the client certificate file",
+          "ssl_key_file": "Path to the client private key file",
+          "query_timeout": "Seconden dat een `scribe.query`-aanroep mag draaien voordat de database hem stopt. Standaard 60.",
+          "query_max_rows": "Rijen die een `scribe.query`-aanroep mag teruggeven voordat hij wordt geweigerd. Ze belanden in het geheugen van Home Assistant, dus dit is wat voorkomt dat een onbedachtzame query het onderuithaalt. Standaard 20000."
+        }
+      }
+    },
+    "error": {
+      "must_record_something": "Ten minste één van 'Statusveranderingen opnemen' of 'Gebeurtenissen opnemen' moet zijn ingeschakeld.",
+      "invalid_interval": "Aanbewaring moet een interval zijn als '365 days', '6 months' of '1 year' — laat het leeg om de historie voor altijd te bewaren.",
+      "invalid_schema": "Een schemanaam mag alleen letters, cijfers en underscores bevatten en niet met een cijfer beginnen — laat hem leeg om het schema van de verbinding zelf te gebruiken.",
+      "invalid_storage_interval": "Chunk-interval en compressie-interval moeten een interval zijn als '7 days', '12 hours' of '1 month' — ze mogen niet leeg blijven."
+    }
+  },
+  "issues": {
+    "rename_refused_live": {
+      "title": "Hernoemen van entiteit naar {new_entity_id} is niet toegepast",
+      "description": "Home Assistant hernoemde `{old_entity_id}` naar `{new_entity_id}`, maar de database van Scribe houdt `{new_entity_id}` al bij voor een andere entiteit die nog actief is (`{occupant}`). Om de historie van twee levende entiteiten niet te vermengen, heeft Scribe de database ongewijzigd gelaten: de tot nu toe opgenomen historie blijft onder `{old_entity_id}`, en nieuwe toestanden kunnen onder de bestaande rij `{new_entity_id}` worden opgenomen. Is de andere entiteit ook net hernoemd, dan lost dit zich meestal binnen een minuut vanzelf op — deze melding verdwijnt zodra het hernoemen slaagt. Blijft het staan, bekijk dan de tabel `entities` in uw database."
+    },
+    "rename_refused_unprovable": {
+      "title": "Hernoemen van entiteit naar {new_entity_id} is niet toegepast",
+      "description": "Home Assistant hernoemde `{old_entity_id}` naar `{new_entity_id}`, maar de database van Scribe heeft al een rij voor `{new_entity_id}` met onvolledige metadata, waardoor Scribe niet kan aantonen dat die bij een verwijderde entiteit hoort. Om de historie niet te beschadigen is de database ongewijzigd gelaten: de tot nu toe opgenomen historie blijft onder `{old_entity_id}`. Weet u zeker dat de bestaande rij `{new_entity_id}` een restant is van een verwijderde entiteit, verwijder hem dan met de hand uit de tabel `entities`; Scribe past het hernoemen dan toe zodra de entiteit opnieuw hernoemd wordt."
+    },
+    "rename_failed": {
+      "title": "Hernoemen van entiteit {old_entity_id} is mislukt",
+      "description": "Scribe liep tegen een fout aan bij het hernoemen van `{old_entity_id}` naar `{new_entity_id}` in de database: {error}. De historie van de entiteit staat nu mogelijk verdeeld over de twee ID's. Bekijk de logs van Home Assistant voor details; de entiteit opnieuw hernoemen probeert het opnieuw."
+    },
+    "db_unreachable": {
+      "title": "Scribe kan zijn database niet bereiken",
+      "description": "Scribe kon geen verbinding maken met `{host}`. De database meldde: {error}\n\nEr bereikt niets de database, maar het opnemen is niet gestopt: toestanden worden in geheugen gehouden en Scribe probeert de verbinding op de achtergrond opnieuw, om daarna alles te schrijven wat gebufferd is. Historie gaat alleen verloren als Home Assistant eerst herstart, of als de buffer volloopt.\n\nControleer of de server draait en bereikbaar is vanuit Home Assistant, en of de URL, gebruikersnaam en het wachtwoord in de instellingen van Scribe kloppen. Deze melding verdwijnt vanzelf zodra een verbinding slaagt."
+    },
+    "write_failing": {
+      "title": "Scribe kan niet naar zijn database schrijven",
+      "description": "De laatste {failures} pogingen om historie te schrijven zijn mislukt. Opgenomen data wordt in geheugen gehouden en wordt geschreven zodra de database herstelt, maar gaat verloren als Home Assistant eerst herstart — of als de buffer volloopt.\n\nDe laatste fout was: {error}\n\nControleer de databaseserver (schijfruimte, verbindingslimieten en zijn eigen logs). Deze melding verdwijnt zodra een schrijfactie slaagt."
+    },
+    "buffer_full": {
+      "title": "De buffer van Scribe is vol — er gaat historie verloren",
+      "description": "Schrijfacties mislukken al zo lang dat de buffer in het geheugen vol is ({max_queue_size} items). De oudste records worden nu weggegooid om plaats te maken voor nieuwe, dus **er gaat historie definitief verloren**.\n\nLos eerst het databaseprobleem op — zie de andere Scribe-reparatie, of de logs van Home Assistant. Is uw database simpelweg trager dan uw tempo aan toestandswijzigingen, verhoog dan de buffergrootte in de instellingen van Scribe. Deze melding verdwijnt zodra het schrijven hervat."
+    },
+    "data_dropped": {
+      "title": "Scribe gooit records weg",
+      "description": "Sinds Home Assistant startte zijn {dropped} records weggegooid, omdat een schrijfactie mislukte terwijl bufferen uitstaat in de instellingen van Scribe.\n\nZet bufferen aan om records door een tijdelijke databasestoring heen in geheugen te houden, en bekijk de logs voor de onderliggende schrijffout."
+    },
+    "no_timescaledb": {
+      "title": "TimescaleDB is niet geïnstalleerd op de database van Scribe",
+      "description": "Scribe schrijft naar `{host}`, maar daar is de TimescaleDB-extensie niet geïnstalleerd. Historie wordt nog steeds opgeslagen en blijft bevraagbaar — maar chunking en **compressie zijn niet beschikbaar**, dus de database groeit aanzienlijk sneller, en de sensoren voor grootte en compressie blijven leeg.\n\nInstalleer de extensie en voer `CREATE EXTENSION timescaledb;` uit op deze database, en herstart daarna Home Assistant. Deze melding verdwijnt zodra de extensie wordt gevonden."
+    },
+    "retention_failed": {
+      "title": "Scribe kon het bewaarbeleid op {table} niet toepassen",
+      "description": "Scribe kreeg de opdracht data ouder dan **{retention}** uit `{table}` te verwijderen, en het instellen van dat beleid mislukte met: {error}\n\nEr is niets verwijderd en er wordt niets verwijderd — de tabel blijft groeien en zijn historie is intact. Aanbewaring is een functie van TimescaleDB: het vereist de extensie op deze database, dat `{table}` een hypertable is, en dat de databasegebruiker van Scribe er eigenaar van is.\n\nLos de oorzaak op, of leeg het bewaarveld in de opties van Scribe, en herstart Home Assistant. Deze melding verdwijnt zodra het beleid staat."
+    },
+    "ssl_degraded": {
+      "title": "De TLS-configuratie van Scribe geldt niet volledig",
+      "description": "Scribe verbindt met zijn database via TLS, maar een deel van wat u instelde kon niet worden toegepast: {problems}\n\nDe verbinding is nog steeds versleuteld, en het certificaat van de server wordt nog steeds tegen de CA-opslag van het systeem gecontroleerd. Wat ontbreekt is de extra bescherming waar u om vroeg — meestal een clientcertificaat, waardoor Scribe zich als gewone client aanmeldt in plaats van als degene die u voorzag, wat er van buiten identiek uitziet tot iemand het nakijkt.\n\nControleer of de paden kloppen en leesbaar zijn voor Home Assistant (relatieve paden gaan uit van de configuratiemap), en herstart daarna. Deze melding verdwijnt zodra elk ingesteld bestand laadt."
+    },
+    "schema_failed": {
+      "title": "Scribe kon zijn tabellen niet aanmaken",
+      "description": "Scribe bereikte `{host}` maar liep vast bij het bouwen van zijn schema, met: {error}\n\nWat het niet kon aanmaken ontbreekt eenvoudigweg: op een nieuwe database betekent dat **er wordt helemaal niets opgenomen**, en op een bestaande kan het opnemen gedeeltelijk zijn — sommige tabellen bijgewerkt, andere verouderd of afwezig. De meest voorkomende oorzaak zijn rechten: de databasegebruiker waarmee Scribe verbindt moet tabellen kunnen aanmaken in deze database, en eigenaar zijn van de tabellen die het al aanmaakte.\n\nKen die rechten toe (of wijs Scribe naar een database waarvan het eigenaar is) en herstart Home Assistant. Deze melding verdwijnt zodra het schema staat."
+    },
+    "view_failed": {
+      "title": "Scribe kon de view `{view}` niet aanmaken",
+      "description": "Toestanden worden normaal opgenomen in `states_raw`, maar de view `{view}` die ze terugleest kon niet worden aangemaakt: {error}\n\nElke query, elk dashboard en elk voorbeeld in de documentatie gaat door die view, dus uw historie lijkt leeg terwijl dat niet zo is. Er is niets verloren.\n\nDit is meestal een rechtenprobleem, of een ander object dat die naam al bezet. Los de oorzaak op en herstart Home Assistant."
+    },
+    "no_hypertable": {
+      "title": "`{table}` is geen TimescaleDB-hypertable",
+      "description": "TimescaleDB is op deze database geïnstalleerd, maar `{table}` is een gewone tabel: hij kon niet worden omgezet. Historie wordt opgenomen en blijft bevraagbaar, maar **chunking, compressie en aanbewaring doen helemaal niets** — verwacht dat de database enkele malen sneller groeit dan nodig, en dat de groottesensoren leeg blijven.\n\nEen tabel omzetten vereist eigenaarschap, dus meestal betekent dit dat de databasegebruiker van Scribe geen eigenaar is van `{table}`. Ken dat eigenaarschap toe en herstart Home Assistant; deze melding verdwijnt zodra de omzetting slaagt."
+    },
+    "no_compression": {
+      "title": "`{table}` wordt nooit gecomprimeerd",
+      "description": "`{table}` is een hypertable, maar er kon geen compressiebeleid worden ingesteld, dus chunks ouder dan {compress_after} worden nooit gecomprimeerd en de tabel houdt zijn volle ongecomprimeerde grootte — doorgaans enkele malen groter dan nodig.\n\nMeestal betekent dit dat de databasegebruiker van Scribe geen eigenaar van de tabel is. Bekijk de logs van Home Assistant voor de precieze fout, los die op, en herstart Home Assistant."
+    },
+    "legacy_schema": {
+      "title": "De database van Scribe dateert van vóór versie 3.0",
+      "description": "De database bevat nog `{relation}` uit de indeling van vóór 3.0, en deze versie van Scribe kan die niet omzetten. **Er wordt niets opgenomen** — en er is ook niets hernoemd, aangemaakt of verwijderd, dus uw historie staat precies waar hij stond.\n\nOm hem om te zetten: installeer Scribe **{version}** (kies die versie expliciet in HACS), start Home Assistant en laat het draaien tot de logs melden dat de migratie klaar is — ongeveer een kwartier op een grote database — en werk Scribe daarna opnieuw bij. Het opnemen hervat bij de volgende herstart, en deze melding verdwijnt.\n\nBegint u liever met een schone database, verwijder dan `{relation}` (dit wist de oude historie) en herstart Home Assistant."
+    },
+    "schema_unavailable": {
+      "title": "Scribe kan het opgegeven schema niet bereiken",
+      "description": "Scribe is ingesteld om in het schema `{schema}` op `{host}` te schrijven, maar de sessie komt in plaats daarvan uit op `{fallback}` — het schema bestaat niet, of de databasegebruiker van Scribe heeft er geen rechten op.\n\n**Er wordt niets opgenomen.** PostgreSQL faalt niet op een ontbrekend schema, het valt stilletjes terug op het volgende op het search path, dus doorgaan zou uw hele historie in `{fallback}` hebben geschreven terwijl de interface `{schema}` bleef tonen. Scribe stopt liever dan het verkeerde schema te vullen.\n\nMaak het aan en ken de rechten toe:\n\n```sql\nCREATE SCHEMA IF NOT EXISTS {schema};\nGRANT USAGE, CREATE ON SCHEMA {schema} TO scribe;\n```\n\nof leeg het schemaveld onder Configureren → Geavanceerd. Herstart daarna Home Assistant — deze melding verdwijnt zodra Scribe in het opgegeven schema schrijft."
+    },
+    "rollups_failed": {
+      "title": "Scribe kon zijn samenvattingen niet bouwen",
+      "description": "Uur- en dagsamenvattingen staan aan, maar Scribe kon ze niet aanmaken: {error}\n\nHet opnemen heeft er geen last van — dit versnelt alleen lange grafieken — en de views states_hourly en states_daily ontbreken. De databasegebruiker heeft het recht nodig om materialized views aan te maken. Scribe probeert het bij elke start opnieuw."
+    }
+  }
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -65,7 +65,7 @@ HACS installs **only `custom_components/scribe/`**. Everything else in the repos
 | `scripts/` | Local helper shell scripts. See [section 15](#15-migration-scripts-and-helper-scripts). |
 | `.github/workflows/` | CI. See [section 6](#6-tests) and [section 9](#9-releasing). |
 | `hacs.json` | HACS metadata, including the **minimum Home Assistant version**. |
-| `README.md`, `README.fr.md`, `README.es.md`, `README.de.md` | User documentation, in four languages, kept in sync by tests. |
+| `README.md`, `README.fr.md`, `README.es.md`, `README.de.md`, `README.nl.md` | User documentation, in five languages, kept in sync by tests. |
 | `CHANGELOG.md` | One entry per user-visible change. See [section 8](#8-changelog). |
 | `docs/DEVELOPMENT.md` | This guide. |
 | `docs/data-structure.md` | User guide to the tables and to querying them. |

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -20,6 +20,9 @@ pytest
 pytest-homeassistant-custom-component==0.13.364
 pytest-asyncio
 psycopg2-binary
+# The migration scripts read their configuration through it, and the
+# integration tests import those scripts.
+python-dotenv
 asyncpg
 ruff==0.16.5
 pycares

--- a/tests/integration/test_migration_scripts.py
+++ b/tests/integration/test_migration_scripts.py
@@ -343,6 +343,23 @@ def influx_record(when, entity_id, domain, value=None, state=None, unit="state")
 
 
 @pytest.fixture
+def influx_env(migration_env, monkeypatch):
+    """The InfluxDB half of the configuration the script reads at import.
+
+    Every test that imports `influx2scribe` needs it: without it the module
+    calls `sys.exit` on a missing INFLUX_TOKEN. That went unnoticed locally
+    because the scripts call `load_dotenv()`, which resolves relative to
+    `migration/` — so a developer's own untracked `migration/.env` filled the
+    gap, and only CI, which has no such file, saw the tests fail.
+    """
+    monkeypatch.setenv("INFLUX_URL", "http://127.0.0.1:8086")
+    monkeypatch.setenv("INFLUX_TOKEN", "token")
+    monkeypatch.setenv("INFLUX_ORG", "org")
+    monkeypatch.setenv("INFLUX_BUCKET", "homeassistant")
+    return migration_env
+
+
+@pytest.fixture
 def fake_influx(monkeypatch):
     """Stand in for `influxdb_client`, so the script can be imported and run.
 
@@ -383,15 +400,8 @@ def fake_influx(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_influx_backfills_states_and_entities(
-    db, migration_env, monkeypatch, fake_influx
-):
+async def test_influx_backfills_states_and_entities(db, influx_env, fake_influx):
     """The record shapes InfluxDB hands back, turned into states_raw rows."""
-    monkeypatch.setenv("INFLUX_URL", "http://127.0.0.1:8086")
-    monkeypatch.setenv("INFLUX_TOKEN", "token")
-    monkeypatch.setenv("INFLUX_ORG", "org")
-    monkeypatch.setenv("INFLUX_BUCKET", "homeassistant")
-
     fake_influx.append(
         influx_record(
             START + timedelta(hours=1), "temperature", "sensor", value=21.5, unit="°C"
@@ -413,7 +423,7 @@ async def test_influx_backfills_states_and_entities(
     assert by_entity["binary_sensor.door"][3] is None
 
 
-def test_influx_prefixes_the_entity_id_with_its_domain(fake_influx):
+def test_influx_prefixes_the_entity_id_with_its_domain(influx_env, fake_influx):
     """Influx stores `entity_id` without the domain; states_raw needs it whole."""
     influx = load_script("influx2scribe")
 
@@ -462,7 +472,7 @@ async def test_ltss_fills_state_as_well_as_value_for_a_number(
     assert (state, value) == ("48.2", 48.2)
 
 
-def test_influx_fills_state_as_well_as_value_for_a_number(fake_influx):
+def test_influx_fills_state_as_well_as_value_for_a_number(influx_env, fake_influx):
     """The same divergence, in the other script. See the LTSS test above."""
     influx = load_script("influx2scribe")
 

--- a/tests/integration/test_migration_scripts.py
+++ b/tests/integration/test_migration_scripts.py
@@ -1,0 +1,482 @@
+"""The backfill scripts in `migration/`, against a real database.
+
+`influx2scribe`, `ltss2scribe` and `recorder2scribe` write straight into
+`entities` and `states_raw` with psycopg2, bypassing everything the writer
+does. Nothing tested them: they were free to drift from the schema Scribe
+creates, and the failure mode is a wall of per-row errors — or worse, a
+successful migration whose rows do not look like the ones Scribe writes.
+
+Each script reads its whole configuration at import time, so every test here
+sets the environment first and imports the module fresh.
+"""
+
+import importlib
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import psycopg2
+import pytest
+
+from tests.integration.conftest import DSN
+
+MIGRATION_DIR = Path(__file__).resolve().parents[2] / "migration"
+
+START = datetime(2026, 8, 1, 0, 0, tzinfo=timezone.utc)
+END = datetime(2026, 8, 1, 6, 0, tzinfo=timezone.utc)
+
+
+def _dsn_parts():
+    """The test DSN, as the host/port/db/user/password the scripts expect."""
+    from urllib.parse import urlparse
+
+    parsed = urlparse(DSN)
+    return {
+        "host": parsed.hostname,
+        "port": str(parsed.port),
+        "database": parsed.path.lstrip("/"),
+        "user": parsed.username,
+        "password": parsed.password,
+    }
+
+
+@pytest.fixture
+def migration_env(monkeypatch, tmp_path):
+    """Point a script at the test database, from a directory it may write to.
+
+    The scripts call `logging.basicConfig` with a `FileHandler` and
+    `load_dotenv()` at import, so the working directory decides where their log
+    lands and whether a stray `.env` on this machine leaks into the test.
+    """
+    parts = _dsn_parts()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SCRIBE_HOST", parts["host"])
+    monkeypatch.setenv("SCRIBE_PORT", parts["port"])
+    monkeypatch.setenv("SCRIBE_DB", parts["database"])
+    monkeypatch.setenv("SCRIBE_USER", parts["user"])
+    monkeypatch.setenv("SCRIBE_PASS", parts["password"])
+    monkeypatch.setenv("MIGRATION_START_TIME", START.isoformat())
+    monkeypatch.setenv("MIGRATION_END_TIME", END.isoformat())
+    monkeypatch.setenv("CHUNK_SIZE", "4")
+    monkeypatch.setenv("PURGE_DESTINATION", "False")
+    return parts
+
+
+def load_script(name):
+    """Import one migration script fresh, with its configuration already set."""
+    sys.path.insert(0, str(MIGRATION_DIR))
+    try:
+        for module in (name, "preflight"):
+            sys.modules.pop(module, None)
+        return importlib.import_module(name)
+    finally:
+        sys.path.remove(str(MIGRATION_DIR))
+
+
+def scribe_rows():
+    """Every migrated state, resolved through `entities`, oldest first."""
+    with psycopg2.connect(DSN) as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT e.entity_id, s.time, s.state, s.value, s.attributes "
+            "FROM states_raw s JOIN entities e ON e.id = s.metadata_id "
+            "ORDER BY s.time, e.entity_id"
+        )
+        return cur.fetchall()
+
+
+# --------------------------------------------------------------------------
+# preflight
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preflight_accepts_the_schema_scribe_creates(db):
+    """The constraints the scripts' ON CONFLICT clauses rely on."""
+    preflight = load_script("preflight")
+    with psycopg2.connect(DSN) as conn, conn.cursor() as cur:
+        preflight.preflight_scribe_schema(cur)  # must not raise or exit
+
+
+@pytest.mark.asyncio
+async def test_preflight_refuses_a_database_scribe_never_built(db):
+    """Better one clear message than a per-chunk error for every row."""
+    preflight = load_script("preflight")
+    with psycopg2.connect(DSN) as conn, conn.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS states_raw CASCADE")
+        conn.commit()
+        with pytest.raises(SystemExit):
+            preflight.preflight_scribe_schema(cur)
+
+
+# --------------------------------------------------------------------------
+# recorder2scribe
+# --------------------------------------------------------------------------
+
+
+def build_recorder_sqlite(path, rows, schema_version=53):
+    """A Home Assistant recorder database, reduced to what the script reads."""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE schema_changes (change_id INTEGER PRIMARY KEY, schema_version INTEGER);
+        CREATE TABLE states_meta (metadata_id INTEGER PRIMARY KEY, entity_id TEXT);
+        CREATE TABLE state_attributes (attributes_id INTEGER PRIMARY KEY, shared_attrs TEXT);
+        CREATE TABLE states (
+            state_id INTEGER PRIMARY KEY,
+            metadata_id INTEGER,
+            state TEXT,
+            last_updated_ts REAL,
+            attributes_id INTEGER
+        );
+        """
+    )
+    conn.execute("INSERT INTO schema_changes VALUES (1, ?)", (schema_version,))
+
+    metadata = {}
+    for index, (entity_id, state, when, attributes) in enumerate(rows, start=1):
+        if entity_id not in metadata:
+            metadata[entity_id] = len(metadata) + 1
+            conn.execute(
+                "INSERT INTO states_meta VALUES (?, ?)",
+                (metadata[entity_id], entity_id),
+            )
+        conn.execute(
+            "INSERT INTO state_attributes VALUES (?, ?)",
+            (index, json.dumps(attributes)),
+        )
+        conn.execute(
+            "INSERT INTO states VALUES (?, ?, ?, ?, ?)",
+            (index, metadata[entity_id], state, when.timestamp(), index),
+        )
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_recorder_sqlite_backfills_states_and_entities(
+    db, migration_env, monkeypatch, tmp_path
+):
+    """The SQLite path the README never documented, end to end."""
+    recorder = tmp_path / "home-assistant_v2.db"
+    build_recorder_sqlite(
+        recorder,
+        [
+            ("sensor.temperature", "21.5", START + timedelta(hours=1), {"unit": "°C"}),
+            ("sensor.temperature", "22.0", START + timedelta(hours=5), {"unit": "°C"}),
+            ("binary_sensor.door", "on", START + timedelta(hours=2), {}),
+        ],
+    )
+    monkeypatch.setenv("RECORDER_TYPE", "sqlite")
+    monkeypatch.setenv("RECORDER_DB_PATH", str(recorder))
+
+    load_script("recorder2scribe").migrate()
+
+    rows = scribe_rows()
+    assert len(rows) == 3
+    assert {row[0] for row in rows} == {"sensor.temperature", "binary_sensor.door"}
+
+    by_entity = {(row[0], row[1]): row for row in rows}
+    numeric = by_entity[("sensor.temperature", START + timedelta(hours=1))]
+    assert numeric[3] == 21.5
+    assert numeric[2] is None, (
+        "a numeric state belongs in `value`, like Scribe writes it"
+    )
+
+    text = by_entity[("binary_sensor.door", START + timedelta(hours=2))]
+    assert text[2] == "on"
+    assert text[3] is None
+
+
+@pytest.mark.asyncio
+async def test_recorder_migration_can_be_run_twice(
+    db, migration_env, monkeypatch, tmp_path
+):
+    """Re-running after an interruption must not duplicate history.
+
+    The whole point of `ON CONFLICT DO NOTHING` on `(metadata_id, time)`: the
+    documented workflow is to migrate while Scribe is already recording.
+    """
+    recorder = tmp_path / "recorder.db"
+    build_recorder_sqlite(
+        recorder,
+        [("sensor.temperature", "21.5", START + timedelta(hours=1), {})],
+    )
+    monkeypatch.setenv("RECORDER_TYPE", "sqlite")
+    monkeypatch.setenv("RECORDER_DB_PATH", str(recorder))
+
+    load_script("recorder2scribe").migrate()
+    load_script("recorder2scribe").migrate()
+
+    assert len(scribe_rows()) == 1
+
+
+@pytest.mark.asyncio
+async def test_recorder_refuses_a_schema_still_migrating(
+    db, migration_env, monkeypatch, tmp_path
+):
+    """A recorder mid-migration would be read half-converted."""
+    recorder = tmp_path / "old.db"
+    build_recorder_sqlite(
+        recorder,
+        [("sensor.temperature", "21.5", START + timedelta(hours=1), {})],
+        schema_version=42,
+    )
+    monkeypatch.setenv("RECORDER_TYPE", "sqlite")
+    monkeypatch.setenv("RECORDER_DB_PATH", str(recorder))
+
+    with pytest.raises(SystemExit):
+        load_script("recorder2scribe").migrate()
+
+    assert scribe_rows() == []
+
+
+@pytest.mark.asyncio
+async def test_recorder_only_migrates_the_configured_window(
+    db, migration_env, monkeypatch, tmp_path
+):
+    """MIGRATION_START_TIME and MIGRATION_END_TIME are a filter, not a hint."""
+    recorder = tmp_path / "recorder.db"
+    build_recorder_sqlite(
+        recorder,
+        [
+            ("sensor.temperature", "1", START - timedelta(hours=1), {}),
+            ("sensor.temperature", "2", START + timedelta(hours=1), {}),
+            ("sensor.temperature", "3", END + timedelta(hours=1), {}),
+        ],
+    )
+    monkeypatch.setenv("RECORDER_TYPE", "sqlite")
+    monkeypatch.setenv("RECORDER_DB_PATH", str(recorder))
+
+    load_script("recorder2scribe").migrate()
+
+    rows = scribe_rows()
+    assert [row[3] for row in rows] == [2.0]
+
+
+# --------------------------------------------------------------------------
+# ltss2scribe
+# --------------------------------------------------------------------------
+
+
+def build_ltss_table(rows):
+    """The single table LTSS records into, in the test database."""
+    with psycopg2.connect(DSN) as conn, conn.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS ltss")
+        cur.execute(
+            "CREATE TABLE ltss (time TIMESTAMPTZ, entity_id TEXT, "
+            "state TEXT, attributes JSONB)"
+        )
+        for entity_id, state, when, attributes in rows:
+            cur.execute(
+                "INSERT INTO ltss VALUES (%s, %s, %s, %s)",
+                (when, entity_id, state, json.dumps(attributes)),
+            )
+        conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_ltss_backfills_states_and_entities(db, migration_env, monkeypatch):
+    """Source and destination are the same server here; the script uses two connections."""
+    build_ltss_table(
+        [
+            ("sensor.humidity", "48.2", START + timedelta(hours=1), {"unit": "%"}),
+            ("binary_sensor.window", "off", START + timedelta(hours=3), {}),
+        ]
+    )
+    parts = migration_env
+    monkeypatch.setenv("LTSS_HOST", parts["host"])
+    monkeypatch.setenv("LTSS_PORT", parts["port"])
+    monkeypatch.setenv("LTSS_DB", parts["database"])
+    monkeypatch.setenv("LTSS_USER", parts["user"])
+    monkeypatch.setenv("LTSS_PASS", parts["password"])
+
+    load_script("ltss2scribe").migrate()
+
+    rows = scribe_rows()
+    assert {row[0] for row in rows} == {"sensor.humidity", "binary_sensor.window"}
+
+    by_entity = {row[0]: row for row in rows}
+    assert by_entity["sensor.humidity"][3] == 48.2
+    assert by_entity["binary_sensor.window"][2] == "off"
+    assert by_entity["binary_sensor.window"][3] is None
+    assert by_entity["sensor.humidity"][4] == {"unit": "%"}
+
+
+@pytest.mark.asyncio
+async def test_ltss_migration_can_be_run_twice(db, migration_env, monkeypatch):
+    """Same guarantee as the recorder script, through a different INSERT."""
+    build_ltss_table([("sensor.humidity", "48.2", START + timedelta(hours=1), {})])
+    parts = migration_env
+    for key in ("HOST", "PORT", "DB", "USER", "PASS"):
+        monkeypatch.setenv(
+            f"LTSS_{key}",
+            parts[{"DB": "database", "PASS": "password"}.get(key, key.lower())],
+        )
+
+    load_script("ltss2scribe").migrate()
+    load_script("ltss2scribe").migrate()
+
+    assert len(scribe_rows()) == 1
+
+
+# --------------------------------------------------------------------------
+# influx2scribe
+# --------------------------------------------------------------------------
+
+
+def influx_record(when, entity_id, domain, value=None, state=None, unit="state"):
+    """One row as `influxdb_client` hands it back: values, plus get_time()."""
+    values = {
+        "_time": when,
+        "entity_id": entity_id,
+        "domain": domain,
+        "_measurement": unit,
+    }
+    if value is not None:
+        values["value"] = value
+    if state is not None:
+        values["state"] = state
+    return SimpleNamespace(values=values, get_time=lambda: when)
+
+
+@pytest.fixture
+def fake_influx(monkeypatch):
+    """Stand in for `influxdb_client`, so the script can be imported and run.
+
+    InfluxDB is the one source with no server to point at here. What matters is
+    the same as for the others: that what it writes matches Scribe's schema.
+    """
+    records = []
+
+    class _QueryApi:
+        def query(self, query, org=None):
+            start, stop = (
+                datetime.fromisoformat(part)
+                for part in query.split("start: ")[1].split(")")[0].split(", stop: ")
+            )
+            kept = [r for r in records if start <= r.get_time() < stop]
+            return [SimpleNamespace(records=kept)] if kept else []
+
+    class _Client:
+        def __init__(self, **kwargs):
+            pass
+
+        def query_api(self):
+            return _QueryApi()
+
+        def close(self):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setitem(
+        sys.modules, "influxdb_client", SimpleNamespace(InfluxDBClient=_Client)
+    )
+    return records
+
+
+@pytest.mark.asyncio
+async def test_influx_backfills_states_and_entities(
+    db, migration_env, monkeypatch, fake_influx
+):
+    """The record shapes InfluxDB hands back, turned into states_raw rows."""
+    monkeypatch.setenv("INFLUX_URL", "http://127.0.0.1:8086")
+    monkeypatch.setenv("INFLUX_TOKEN", "token")
+    monkeypatch.setenv("INFLUX_ORG", "org")
+    monkeypatch.setenv("INFLUX_BUCKET", "homeassistant")
+
+    fake_influx.append(
+        influx_record(
+            START + timedelta(hours=1), "temperature", "sensor", value=21.5, unit="°C"
+        )
+    )
+    fake_influx.append(
+        influx_record(START + timedelta(hours=2), "door", "binary_sensor", state="on")
+    )
+
+    load_script("influx2scribe").migrate()
+
+    rows = scribe_rows()
+    assert {row[0] for row in rows} == {"sensor.temperature", "binary_sensor.door"}
+
+    by_entity = {row[0]: row for row in rows}
+    assert by_entity["sensor.temperature"][3] == 21.5
+    assert by_entity["sensor.temperature"][4]["unit_of_measurement"] == "°C"
+    assert by_entity["binary_sensor.door"][2] == "on"
+    assert by_entity["binary_sensor.door"][3] is None
+
+
+def test_influx_prefixes_the_entity_id_with_its_domain(fake_influx):
+    """Influx stores `entity_id` without the domain; states_raw needs it whole."""
+    influx = load_script("influx2scribe")
+
+    assert (
+        influx._record_entity_id(
+            SimpleNamespace(values={"entity_id": "temperature", "domain": "sensor"})
+        )
+        == "sensor.temperature"
+    )
+    assert (
+        influx._record_entity_id(
+            SimpleNamespace(
+                values={"entity_id": "sensor.temperature", "domain": "sensor"}
+            )
+        )
+        == "sensor.temperature"
+    )
+    assert influx._record_entity_id(SimpleNamespace(values={})) is None
+
+
+@pytest.mark.asyncio
+async def test_ltss_fills_state_as_well_as_value_for_a_number(
+    db, migration_env, monkeypatch
+):
+    """Pinned, not endorsed: this is where the scripts diverge from Scribe.
+
+    `_state_row` in the integration leaves `state` NULL for a numeric state and
+    puts the number in `value`. `recorder2scribe` does the same, but
+    `ltss2scribe` and `influx2scribe` also write the text into `state`, so a
+    migrated history and a recorded one do not look alike in the same table:
+    `SELECT state FROM states` returns the number for migrated rows and NULL
+    for everything Scribe wrote afterwards. Changing it is a data decision, so
+    the behaviour is nailed down here rather than quietly altered.
+    """
+    build_ltss_table([("sensor.humidity", "48.2", START + timedelta(hours=1), {})])
+    parts = migration_env
+    monkeypatch.setenv("LTSS_HOST", parts["host"])
+    monkeypatch.setenv("LTSS_PORT", parts["port"])
+    monkeypatch.setenv("LTSS_DB", parts["database"])
+    monkeypatch.setenv("LTSS_USER", parts["user"])
+    monkeypatch.setenv("LTSS_PASS", parts["password"])
+
+    load_script("ltss2scribe").migrate()
+
+    entity_id, _, state, value, _ = scribe_rows()[0]
+    assert (state, value) == ("48.2", 48.2)
+
+
+def test_influx_fills_state_as_well_as_value_for_a_number(fake_influx):
+    """The same divergence, in the other script. See the LTSS test above."""
+    influx = load_script("influx2scribe")
+
+    assert influx._record_state(SimpleNamespace(values={"value": 21.5})) == (
+        "21.5",
+        21.5,
+    )
+    assert influx._record_state(SimpleNamespace(values={"state": "on"})) == ("on", None)
+
+
+@pytest.fixture(autouse=True)
+def _drop_ltss():
+    """The LTSS source table is not Scribe's, so the shared teardown ignores it."""
+    yield
+    with psycopg2.connect(DSN) as conn, conn.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS ltss")
+        conn.commit()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -169,7 +169,7 @@ def _keys(node, prefix=""):
 
 
 def test_the_documented_languages_are_fully_translated():
-    """English, French, Spanish and German — the four the README exists in.
+    """The five the README exists in: English, French, Spanish, German, Dutch.
 
     A missing key falls back to English silently, which is how the whole
     Repairs panel stayed untranslated for three of them without anyone
@@ -181,7 +181,7 @@ def test_the_documented_languages_are_fully_translated():
     root = Path(__file__).resolve().parents[1] / "custom_components" / "scribe"
     reference = _keys(json.loads((root / "strings.json").read_text()))
 
-    for language in ("en", "fr", "es", "de"):
+    for language in ("en", "fr", "es", "de", "nl"):
         path = root / "translations" / f"{language}.json"
         missing = reference - _keys(json.loads(path.read_text()))
         assert not missing, f"{language}.json is missing {sorted(missing)}"
@@ -209,7 +209,7 @@ def test_every_placeholder_survives_translation():
     root = Path(__file__).resolve().parents[1] / "custom_components" / "scribe"
     reference = json.loads((root / "strings.json").read_text())["issues"]
 
-    for language in ("fr", "es", "de"):
+    for language in ("fr", "es", "de", "nl"):
         translated = json.loads(
             (root / "translations" / f"{language}.json").read_text()
         )["issues"]
@@ -262,7 +262,8 @@ def _yaml_schema_keys():
 
 
 @pytest.mark.parametrize(
-    "readme", ["README.md", "README.fr.md", "README.es.md", "README.de.md"]
+    "readme",
+    ["README.md", "README.fr.md", "README.es.md", "README.de.md", "README.nl.md"],
 )
 def test_every_yaml_option_is_documented_in_every_readme(readme):
     """ "Full Configuration" and "Parameter Reference" have to mean it.
@@ -289,7 +290,8 @@ def test_every_yaml_option_is_documented_in_every_readme(readme):
 
 
 @pytest.mark.parametrize(
-    "readme", ["README.md", "README.fr.md", "README.es.md", "README.de.md"]
+    "readme",
+    ["README.md", "README.fr.md", "README.es.md", "README.de.md", "README.nl.md"],
 )
 def test_no_readme_documents_an_option_that_does_not_exist(readme):
     """A documented key nothing reads is worse than an undocumented one."""
@@ -314,7 +316,7 @@ def test_no_readme_documents_an_option_that_does_not_exist(readme):
 ALLOWED_IDENTICAL_TO_ENGLISH = {("fr", "options.step.performance.title")}
 
 
-@pytest.mark.parametrize("language", ["fr", "es", "de"])
+@pytest.mark.parametrize("language", ["fr", "es", "de", "nl"])
 def test_no_documented_language_is_secretly_still_english(language):
     """Key-presence is not translation.
 


### PR DESCRIPTION
## What I checked, and what was wrong

Each collapsed topic, read against what the integration actually does:

| Section | Verdict |
| --- | --- |
| Parameter reference | **Complete** — a test already enforces it against `CONFIG_SCHEMA` in both directions |
| Storage tuning | **Correct** as written |
| Retention | **Correct** as written |
| Summaries | Correct, but silent on where the option is, how often TimescaleDB refreshes, and what happens to non-numeric states |
| Database schema | **Mismatched** — titled "tables, views and how to query them", entirely about the `db_schema` option |
| Statistics sensors | **One wrong entity** — `sensor.scribe_write_duration` does not exist |
| Dashboard | **Correct**, and the entity IDs match the Lovelace files |
| Migrating | **Three real gaps** |

### The defects

- `sensor.scribe_write_duration` is not an entity. The sensor's key is `write_duration` but its name is "Last Write Duration", so the entity is `sensor.scribe_last_write_duration` — which is what `lovelace_scribe_card.yaml` uses, and what a live instance records.
- **Seven links pointed at anchors that never existed** (`#retention`, `#storage-tuning`, `#database-schema`). Those sections are `<details><summary>` blocks, which GitHub does not turn into headings, so every one of them was dead in all four languages.
- **GitHub alerts do not render inside an HTML block.** Both `> [!IMPORTANT]` and `> [!WARNING]` sat inside a `<details>`, so readers saw the literal marker.
- The migration guide repeated the same four steps three times, named `.env` sections that do not exist in `.env.example`, and never mentioned `RECORDER_TYPE` — leaving the SQLite recorder path undocumented.
- The summaries section did not say that `value_avg`/`min`/`max` are empty for non-numeric states while `samples` still counts them.

## What else changed

- Every option in the full configuration carries a one-line comment, grouped by what it does, with `db_url` marked as the only required one at the top.
- "Related projects" is gone; the card section keeps no screenshot.
- Four leftover `#### Show …` headings removed, rules between the three zones of the page, one blank line between topics.
- About a hundred lines shorter in each language.

## Dutch

`README.nl.md`, and the language bar updated everywhere.

`nl.json` was already shipped but covered barely half of `strings.json`: all fourteen Repairs issues, the retention and schema options, the query ceilings and three validation errors fell back to English. It is complete now, and `nl` is in the parametrised lists so the three tests that keep the other languages honest cover it too.